### PR TITLE
Updates rate limiter key generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sto-info-backend",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sto-info-backend",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.965.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sto-info-backend",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Star Trek Online Information APIs",
   "author": "Steve Roberts",
   "private": true,

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,10 @@ import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 import { connectionSourcePromise } from 'config/typeorm.datasource';
 import { json, NextFunction, Request, Response, urlencoded } from 'express';
-import rateLimit, { RateLimitRequestHandler } from 'express-rate-limit';
+import rateLimit, {
+  ipKeyGenerator,
+  RateLimitRequestHandler,
+} from 'express-rate-limit';
 import helmet from 'helmet';
 import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
@@ -49,7 +52,9 @@ function createRateLimiter(options: {
       });
     },
     skipSuccessfulRequests: false,
-    keyGenerator: (req: Request) => req.clientIp ?? req.ip,
+    keyGenerator: (req: Request) => {
+      return ipKeyGenerator(req.clientIp ?? req.ip ?? '');
+    },
   });
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,8 +42,8 @@ function createRateLimiter(options: {
     standardHeaders: true,
     legacyHeaders: false,
     handler: (_req: Request, res: Response) => {
-      res.status(429).json({
-        status: 429,
+      res.status(HttpStatus.TOO_MANY_REQUESTS).json({
+        status: HttpStatus.TOO_MANY_REQUESTS,
         error: errorMessage,
         message: fullErrorMessage,
       });


### PR DESCRIPTION
Updates rate limiter key generation to use `ipKeyGenerator` to properly handle IPv6 addresses. This ensures accurate rate limiting based on IP addresses.

Relates to SC-400