### PR TITLE
Fixes email template path and dev setup

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -318,7 +318,7 @@ Document any caching strategies here (e.g., Redis, in-memory cache, HTTP caching
 
 ### Development Scripts
 
-- `npm run start:dev`: Start the application in development mode with hot-reload and watch mode. Use this for local development.
+- `npm run start:dev`: Copy email templates and start the application in development mode with hot-reload and watch mode. Use this for local development.
 - `npm run start:watch`: Alias for `start:dev`. Use for local development with auto-reload.
 - `npm run start:debug`: Start the application with debugging enabled and watch mode. Use when you need to attach a debugger.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sto-info-backend",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sto-info-backend",
-      "version": "1.0.26",
+      "version": "1.0.27",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.966.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "cross-env TZ=UTC node dist/src/main",
     "start:prod": "cross-env TZ=UTC node dist/src/main",
     "start:render": "npm run migration:run && npm run start:prod",
-    "start:dev": "cross-env TZ=UTC nest start --watch",
+    "start:dev": "npm run assets:copy && cross-env TZ=UTC nest start --watch",
     "start:watch": "npm run start:dev",
     "start:debug": "cross-env TZ=UTC nest start --debug --watch",
     "start:dist": "npm run build && npm run migration:run && npm run start:prod",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sto-info-backend",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "description": "Star Trek Online Information APIs",
   "author": "Steve Roberts",
   "private": true,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -167,7 +167,8 @@ export class AuthService {
     const emailHtmlContent = await ejs.renderFile(
       path.join(
         __dirname,
-        '../..',
+        '..',
+        'views',
         'email-templates',
         'registration-welcome-email.ejs',
       ),

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -17,7 +17,8 @@ export class MailService {
 
   private readonly emailTemplatePath = path.join(
     __dirname,
-    '../..',
+    '..',
+    'views',
     'email-templates',
   );
 


### PR DESCRIPTION
Corrects the email template path and updates the local development command.

- The email templates path was incorrect, causing issues with sending emails.
- The local development setup now copies the email templates before starting the application, ensuring that the templates are available.

Relates to SC-403