### PR TITLE
Improves logout and JWT handling

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -104,14 +104,13 @@ export class AuthController {
     return this.authService.login(userLoginDto);
   }
 
-  @UseGuards(AuthGuard('jwt'))
   @Post('logout')
   @HttpCode(HttpStatus.OK)
   @ApiBearerAuth()
   @ApiOperation({
     summary: 'Log out the current session',
     description:
-      'Revokes the supplied refresh token, preventing further access-token refresh for that session.',
+      'Revokes the supplied refresh token, preventing further access-token refresh for that session. This endpoint works even if the access token has expired, as long as a valid tokenId is provided.',
   })
   @ApiBody({
     schema: {
@@ -132,7 +131,8 @@ export class AuthController {
     description: 'Logout successful. The refresh token is revoked.',
   })
   @ApiUnauthorizedResponse({
-    description: 'Missing or invalid access token.',
+    description:
+      'Missing or invalid access token (Optional for logout if tokenId is provided).',
   })
   async logout(@Body() body: { tokenId: string }): Promise<void> {
     await this.refreshTokenService.revokeUserRefreshToken(body.tokenId);

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -29,6 +29,9 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
           done(error, null);
         }
       },
+      jsonWebTokenOptions: {
+        clockTolerance: 30, // 30 seconds buffer for expiry
+      },
     });
   }
 

--- a/src/mail/mail.service.spec.ts
+++ b/src/mail/mail.service.spec.ts
@@ -192,6 +192,44 @@ describe('MailService', () => {
         service.generateEmailMessageObject('invalid', 'sub', 'text', 'html'),
       ).toThrow('Invalid email format');
     });
+
+    it('should append environment to subject when NODE_ENV is not prod', () => {
+      process.env.NODE_ENV = 'development';
+      const result = service.generateEmailMessageObject(
+        'test@example.com',
+        'Test Subject',
+        'text',
+        'html',
+      );
+      expect(result.subject).toBe('Test Subject [development]');
+    });
+
+    it('should not append environment to subject when NODE_ENV is prod', () => {
+      process.env.NODE_ENV = 'prod';
+      const result = service.generateEmailMessageObject(
+        'test@example.com',
+        'Test Subject',
+        'text',
+        'html',
+      );
+      expect(result.subject).toBe('Test Subject');
+    });
+
+    it('should return correct message object structure', () => {
+      const result = service.generateEmailMessageObject(
+        'test@example.com',
+        'Test Subject',
+        'Test text',
+        '<html>Test html</html>',
+      );
+      expect(result).toHaveProperty('to', 'test@example.com');
+      expect(result).toHaveProperty('from');
+      expect(result.from).toHaveProperty('name', 'Test App');
+      expect(result.from).toHaveProperty('email', 'no-reply@test.local');
+      expect(result).toHaveProperty('subject');
+      expect(result).toHaveProperty('text', 'Test text');
+      expect(result).toHaveProperty('html', '<html>Test html</html>');
+    });
   });
 
   describe('validateEnvironmentVariables', () => {

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -262,10 +262,15 @@ export class MailService {
       throw new Error('Invalid email format');
     }
 
+    const finalSubject =
+      process.env.NODE_ENV === 'prod'
+        ? subject
+        : `${subject} [${process.env.NODE_ENV}]`;
+
     return {
       to,
       from: this.noReplyEmailFromSender,
-      subject,
+      subject: finalSubject,
       text,
       html,
     };


### PR DESCRIPTION
Improves the logout process and JWT handling:

- Clarifies the logout endpoint's behavior, allowing token revocation with just the tokenId, even if the access token is expired.
- Adds a clock tolerance to the JWT strategy to accommodate minor clock drifts, preventing premature token expiry.
- Prefixes email subjects with the environment name in non-production environments, aiding in debugging and identification.

Relates to SC-399