### PR TITLE
Adds GH_PAT_REPO_TOKEN for workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   bump_version:
     runs-on: ubuntu-latest
+    environment: Development
 
     # Hardening:
     # - Do not run on the bot itself (prevents loops)
@@ -30,6 +31,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT_REPO_TOKEN }}
 
       - name: Set up Node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0


### PR DESCRIPTION
Adds a `GH_PAT_REPO_TOKEN` to the workflow to enable fetching the repository with sufficient permissions.

This resolves potential authorization issues when the workflow interacts with the repository.