### PR TITLE
Update Dependabot schedule times

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-      time: '18:00'
+      time: '16:00'
       timezone: 'Europe/London'
     open-pull-requests-limit: 10
     versioning-strategy: 'increase'
@@ -35,7 +35,7 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'monday'
-      time: '18:00'
+      time: '15:00'
       timezone: 'Europe/London'
     open-pull-requests-limit: 10
     labels:


### PR DESCRIPTION
Changed the scheduled time for npm and weekly updates from 18:00 to 16:00 and 15:00 respectively.