### PR TITLE
ci(workflows): Refactors workflow permissions

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -9,9 +9,8 @@ on:
 env:
   NODE_VERSION: 24
 
-# Declare default permissions as read only.
-permissions:
-  contents: read
+# Declare default permissions as none.
+permissions: {}
 
 jobs:
   update-contributors:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,12 +7,13 @@ on:
 env:
   NODE_VERSION: 24
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -13,9 +13,7 @@ on:
       - development
       - production
 
-permissions:
-  contents: read
-  actions: read
+permissions: {}
 
 env:
   NODE_VERSION: 24

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 0 * * 0' # Run every Sunday at midnight
   workflow_dispatch: # Allow manual trigger
 
+permissions: {}
+
 env:
   NODE_VERSION: 24
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [production]
 
+permissions: {}
+
 env:
   NODE_VERSION: 24
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -4,10 +4,7 @@ on:
   push:
     branches: [development]
 
-permissions:
-  contents: write
-  pull-requests: write
-  actions: read
+permissions: {}
 
 env:
   NODE_VERSION: 24
@@ -21,6 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: Development
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
 
     # Hardening: prevent infinite loops
     # - Skip if the commit message matches our version bump pattern


### PR DESCRIPTION
## Description

Refactors the GitHub workflow configurations to use job-level permissions instead of workflow-level permissions for enhanced security and clarity. This change centralises permission definitions within the specific jobs that require them.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation where necessary.
- [x] I have considered the security implications of these changes.
- [x] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

This refactoring enhances security by limiting the permissions granted to each workflow job to the minimum necessary, reducing the potential impact of compromised credentials.