### PR TITLE
feat(release): Reduces version bump noise in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - version-bump
+    authors:
+      - github-actions[bot]
+  categories:
+    - title: 🚀 Features
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: 🧹 Maintenance
+      labels:
+        - chore
+        - refactor
+    - title: 🧪 Testing
+      labels:
+        - test
+        - testing

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,6 +19,7 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repo
@@ -52,3 +53,20 @@ jobs:
 
           git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
           git push origin "$TAG_NAME"
+
+      - name: Unmask last version bump in release notes
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_REPO_TOKEN || github.token }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          echo "Finding PR for version $VERSION..."
+
+          # Search for the merged version bump PR
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --state merged --search "chore: bump version to $VERSION" --json number --jq '.[0].number' || echo "")
+
+          if [ -n "$PR_NUMBER" ]; then
+            echo "Removing 'version-bump' label from PR #$PR_NUMBER to include it in release notes."
+            gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --remove-label version-bump || echo "Failed to remove label, but continuing..."
+          else
+            echo "No matching version bump PR found for version $VERSION."
+          fi

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -65,6 +65,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Ensure the labels exist
+          gh label create version-bump --color "ededed" --description "Automated version bump" || true
+          gh label create chore --color "ededed" --description "Maintenance task" || true
+
+
           CURRENT_VERSION="$(node -p "require('./package.json').version")"
           echo "Current version: $CURRENT_VERSION"
 
@@ -103,7 +108,8 @@ jobs:
             --title "chore: bump version to $NEW_VERSION" \
             --body "Automated version bump from $CURRENT_VERSION to $NEW_VERSION" \
             --base development \
-            --head "$BRANCH_NAME")
+            --head "$BRANCH_NAME" \
+            --label "version-bump,chore")
 
           echo "PR_URL=$PR_URL" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
## Description

Reduces the noise caused by version bump commits in automatically generated release notes by:
- Automatically applying and removing the 'version-bump' label to version bump PRs
- Excluding commits with the 'version-bump' label from the release notes

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [ ] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation where necessary.
- [ ] I have considered the security implications of these changes.
- [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

This change enhances the clarity of release notes by preventing automated version bump commits from cluttering the release notes.

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>