### PR TITLE
fix(readme): Corrects OpenSSF Best Practices badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Security posture
 
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11991/badge)](https://www.bestpractices.dev/projects/11942)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11991/badge)](https://www.bestpractices.dev/projects/11991)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/sto-info-app/sto-info-backend/badge)](https://securityscorecards.dev/viewer/?uri=github.com/sto-info-app/sto-info-backend)
 [![Security Policy](https://img.shields.io/badge/security%20policy-SECURITY.md-informational)](https://github.com/sto-info-app/sto-info-backend/blob/development/SECURITY.md)
 


### PR DESCRIPTION
## Description

Corrects the URL for the OpenSSF Best Practices badge in the README file. The previous link pointed to an incorrect project ID, and this change updates it to the correct ID, ensuring the badge accurately reflects the project's best practices status.

## Type of Change

- [x] Bug fix

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation where necessary.
- [ ] I have considered the security implications of these changes.
- [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>