### PR TITLE
fix(workflow): Automates release note generation

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [production]
 
+# Declare default permissions as read only.
 permissions: {}
 
 env:
@@ -18,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # To create and push tags
+      pull-requests: write # To unmask the last version bump PR
 
     steps:
       - name: Checkout repo
@@ -56,7 +57,7 @@ jobs:
 
       - name: Unmask last version bump in release notes
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_REPO_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           echo "Finding PR for version $VERSION..."
@@ -70,3 +71,14 @@ jobs:
           else
             echo "No matching version bump PR found for version $VERSION."
           fi
+
+      - name: Create Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: Release v${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Description

Updates the `tag-release.yml` workflow to automatically create a GitHub release and generate release notes upon pushes to the `production` branch. This change streamlines the release process by automating the creation of release artefacts and associated documentation, reducing manual effort and ensuring consistency. It also simplifies the usage of the GitHub token within the workflow steps.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation where necessary.
- [x] I have considered the security implications of these changes.
- [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes


Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>