### PR TITLE
fix(ci): Improve API version checks and exclude from rate limits

### DIFF
--- a/.github/workflows/security-zap-dev.yml
+++ b/.github/workflows/security-zap-dev.yml
@@ -84,12 +84,13 @@ jobs:
             fi
           done
 
-          # Now verify version
+          # Now verify version (capture HTTP code so we see 404/500/429 etc. when it fails)
           for attempt in $(seq 1 $max_attempts); do
-            # Capture actual version, allowing for errors to be diagnosed
-            actual_version=$(curl -fsSL --proto '=https' --proto-redir '=https' "${DEV_API_VERSION_URL}" 2>/dev/null | tr -d '\r\n' || echo "")
-            
-            if [ -n "${actual_version}" ]; then
+            version_response=$(curl -sSL -w "\n%{http_code}" --proto '=https' --proto-redir '=https' "${DEV_API_VERSION_URL}" 2>/dev/null || true)
+            http_code=$(echo "${version_response}" | tail -n1)
+            actual_version=$(echo "${version_response}" | sed '$d' | tr -d '\r\n')
+
+            if [ "${http_code}" = "200" ] && [ -n "${actual_version}" ]; then
               echo "Deployed API version: ${actual_version}"
               if [ "${actual_version}" = "${expected_version}" ]; then
                 echo "Version check OK (${actual_version})"
@@ -97,11 +98,10 @@ jobs:
               fi
               echo "Attempt ${attempt}/${max_attempts}: version mismatch (Actual: $actual_version)"
             else
-              echo "Attempt ${attempt}/${max_attempts}: /version returned empty or errored"
-              # Diagnostic: show one verbose curl on failure
+              echo "Attempt ${attempt}/${max_attempts}: /version returned empty or errored (HTTP ${http_code})"
               if [ "${attempt}" -eq "${max_attempts}" ]; then
-                echo "Final diagnostic check:"
-                curl -v --proto '=https' --proto-redir '=https' "${DEV_API_VERSION_URL}" 2>&1 | head -n 30 || true
+                echo "Final diagnostic: GET ${DEV_API_VERSION_URL} -> HTTP ${http_code}, body length: $(echo -n "${actual_version}" | wc -c)"
+                curl -v --proto '=https' --proto-redir '=https' "${DEV_API_VERSION_URL}" 2>&1 | head -n 40 || true
               fi
             fi
 

--- a/.github/workflows/security-zap-prod.yml
+++ b/.github/workflows/security-zap-prod.yml
@@ -82,9 +82,12 @@ jobs:
           done
 
           for attempt in $(seq 1 $max_attempts); do
-            actual_version=$(curl -fsSL --proto '=https' --proto-redir '=https' "${PROD_API_VERSION_URL}" 2>/dev/null | tr -d '\r\n' || echo "")
-            
-            if [ -n "${actual_version}" ]; then
+            # Use -w to capture HTTP code; -f would hide body on 4xx/5xx
+            version_response=$(curl -sSL -w "\n%{http_code}" --proto '=https' --proto-redir '=https' "${PROD_API_VERSION_URL}" 2>/dev/null || true)
+            http_code=$(echo "${version_response}" | tail -n1)
+            actual_version=$(echo "${version_response}" | sed '$d' | tr -d '\r\n')
+
+            if [ "${http_code}" = "200" ] && [ -n "${actual_version}" ]; then
               echo "Deployed API version: ${actual_version}"
               if [ "${actual_version}" = "${expected_version}" ]; then
                 echo "Version check OK (${actual_version})"
@@ -92,7 +95,10 @@ jobs:
               fi
               echo "Attempt ${attempt}/${max_attempts}: version mismatch (Actual: $actual_version)"
             else
-              echo "Attempt ${attempt}/${max_attempts}: /version returned empty or errored"
+              echo "Attempt ${attempt}/${max_attempts}: /version returned empty or errored (HTTP ${http_code})"
+              if [ "${attempt}" -eq "${max_attempts}" ]; then
+                echo "Final diagnostic: GET ${PROD_API_VERSION_URL} -> HTTP ${http_code}, body length: $(echo -n "${actual_version}" | wc -c)"
+              fi
             fi
 
             if [ "${attempt}" -lt "${max_attempts}" ]; then

--- a/src/shared/constants/rate-limit.constants.ts
+++ b/src/shared/constants/rate-limit.constants.ts
@@ -73,5 +73,6 @@ export const EXPENSIVE_RATE_LIMITED_ROUTES = [
 
 /**
  * Paths that should be excluded from rate limiting
+ * (e.g. health/version used by orchestration and CI)
  */
-export const RATE_LIMIT_EXCLUDED_PATHS = ['/health/'] as const;
+export const RATE_LIMIT_EXCLUDED_PATHS = ['/health/', '/version'] as const;


### PR DESCRIPTION
## Description

Enhances the API version verification process within the CI security workflows (ZAP tests) to improve reliability and diagnostic capabilities. Previously, intermittent failures were observed, potentially due to unreliable version checks or rate limiting. This change modifies the `curl` command to explicitly capture and validate the HTTP status code (expecting 200 OK) in addition to checking for a non-empty response body. Diagnostic messages have been improved to include the HTTP status code, and the final diagnostic curl output limit has been increased. Furthermore, the `/version` endpoint is now excluded from rate limiting to prevent it from being throttled by CI and orchestration tools.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation where necessary.
- [x] I have considered the security implications of these changes.
- [x] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

Addresses issues related to failing backend ZAP tests in CI, as detailed in SC-895.

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>