### PR TITLE
ci(workflows): streamline CI for automated PRs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -49,13 +49,8 @@ jobs:
     # Run if pkg_changed or push or schedule/dispatch
     if: |
       github.actor != 'dependabot[bot]' &&
-      github.actor != 'github-actions[bot]' &&
       (needs.check_changes.outputs.pkg_changed == 'true' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'push') &&
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      !(github.event_name == 'pull_request' && (
-        (github.event.pull_request.user.login == 'github-actions[bot]' && startsWith(github.event.pull_request.title, 'chore: bump version to')) ||
-        startsWith(github.event.pull_request.head.ref, 'chore/bump-version-to-')
-      ))
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -24,6 +24,15 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ secrets.GH_PAT_REPO_TOKEN || github.token }}
+          fetch-depth: 0
+
+      - name: Create branch for contributors update
+        run: |
+          BRANCH_NAME="chore/update-contributors-${{ github.run_id }}"
+          git checkout -b "$BRANCH_NAME"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
 
       - name: Update Contributors (CONTRIBUTORS.md)
         uses: akhilmhdh/contributors-readme-action@83ea0b4f1ac928fbfe88b9e8460a932a528eb79f # v2.3.11
@@ -31,8 +40,25 @@ jobs:
           image_size: 100
           readme_path: CONTRIBUTORS.md
           commit_message: |
-            docs: update contributors [skip ci]
+            docs: update contributors
 
             Signed-off-by: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT_REPO_TOKEN || github.token }}
+
+      - name: Create Pull Request
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_REPO_TOKEN || github.token }}
+        run: |
+          # If there are any commits on the current branch that are not in development
+          if [ $(git rev-list --count origin/development..HEAD) -gt 0 ]; then
+            git push origin "$BRANCH_NAME"
+            gh pr create \
+              --title "docs: update contributors" \
+              --body "Automated contributors update for CONTRIBUTORS.md" \
+              --label "chore" \
+              --base development \
+              --head "$BRANCH_NAME" || echo "PR already exists"
+          else
+            echo "No changes detected, skipping PR creation."
+          fi

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -106,13 +106,8 @@ jobs:
     # ONLY RUN if src_changed is true OR if it's a push (to keep badges updated)
     if: |
       github.actor != 'dependabot[bot]' &&
-      github.actor != 'github-actions[bot]' &&
       (needs.check_changes.outputs.src_changed == 'true' || github.event_name == 'push') &&
-      (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-      !(github.event_name == 'pull_request' && (
-        (github.event.pull_request.user.login == 'github-actions[bot]' && startsWith(github.event.pull_request.title, 'chore: bump version to')) ||
-        startsWith(github.event.pull_request.head.ref, 'chore/bump-version-to-')
-      ))
+      (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ github.token }}
+          token: ${{ secrets.GH_PAT_REPO_TOKEN || github.token }}
 
       - name: Set up Node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
@@ -86,7 +86,7 @@ jobs:
       - name: Bump patch version and create PR
         id: create_pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_PAT_REPO_TOKEN || github.token }}
         run: |
           # Configure git to use the bot's identity
           git config user.name "github-actions[bot]"
@@ -143,4 +143,3 @@ jobs:
             --label "version-bump,chore" \
             --base development \
             --head "$BRANCH_NAME"
-


### PR DESCRIPTION
## Description

Refactors and enhances several CI workflows to improve the handling and transparency of automated processes.

The `contributors` workflow has been updated to create a pull request (PR) for contributor updates instead of directly committing changes. This change allows for reviewability of `CONTRIBUTORS.md` updates and removes the `[skip ci]` directive, ensuring proper CI checks are performed on these automated changes. Authentication for this workflow now prioritises a Personal Access Token (PAT).

The `version-bump` workflow now explicitly uses a PAT as a fallback for the GitHub token, ensuring consistent and reliable authentication for pushing version updates and creating associated PRs. This addresses potential permission issues with the default `github.token` in certain automated contexts.

Finally, the `audit` and `lint-test` workflows have been modified to remove specific exclusions for pull requests generated by `github-actions[bot]`. This ensures that automated PRs, such as those for version bumps or contributor updates, will now correctly trigger and pass the necessary CI checks, maintaining code quality and compliance across all changes.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation where necessary.
- [ ] I have considered the security implications of these changes.
- [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

These changes collectively enhance the robustness and transparency of automated CI workflows by ensuring all automated PRs are subject to standard CI checks and benefit from more reliable authentication mechanisms.

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>