### PR TITLE
chore(deps, ci): Update dependencies and CI workflows

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Create branch for contributors update
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           BRANCH_NAME="chore/update-contributors-${{ github.run_id }}"
           git checkout -b "$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -48,7 +48,11 @@ jobs:
               const sha = c.sha;
               const message = (c.commit && c.commit.message) ? c.commit.message : '';
               const isMerge = c.parents && c.parents.length > 1;
-              const isBot = c.author && c.author.type === 'Bot';
+              const isBot = (c.author && c.author.type === 'Bot') || 
+                            (c.commit && c.commit.author && (
+                              (c.commit.author.name && c.commit.author.name.includes('[bot]')) ||
+                              (c.commit.author.email && c.commit.author.email.includes('[bot]'))
+                            ));
 
               if (isMerge || isBot) {
                 continue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -386,32 +386,32 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.999.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.999.0.tgz",
-      "integrity": "sha512-6ML2ls4nnOxm1kKzy2RgM+i8aS/9wgw6V91iqSibBYU/isYs8BvC2xcv8AsaWG5mOQjytjRzsBO5COxfWVPg3A==",
+      "version": "3.998.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.998.0.tgz",
+      "integrity": "sha512-XkJ6GN+egutEHSa9+t4OngCRyyP6Zl+4FX+hN7rDqlLjPuK++NHdMVrRSaVq1/H1m0+Nif0Rtz1BiTYP/htmvg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/credential-provider-node": "^3.972.14",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.6",
-        "@aws-sdk/middleware-expect-continue": "^3.972.6",
-        "@aws-sdk/middleware-flexible-checksums": "^3.973.1",
-        "@aws-sdk/middleware-host-header": "^3.972.6",
-        "@aws-sdk/middleware-location-constraint": "^3.972.6",
-        "@aws-sdk/middleware-logger": "^3.972.6",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.15",
-        "@aws-sdk/middleware-ssec": "^3.972.6",
-        "@aws-sdk/middleware-user-agent": "^3.972.15",
-        "@aws-sdk/region-config-resolver": "^3.972.6",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.3",
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/util-endpoints": "^3.996.3",
-        "@aws-sdk/util-user-agent-browser": "^3.972.6",
-        "@aws-sdk/util-user-agent-node": "^3.973.0",
+        "@aws-sdk/core": "^3.973.14",
+        "@aws-sdk/credential-provider-node": "^3.972.13",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.5",
+        "@aws-sdk/middleware-expect-continue": "^3.972.5",
+        "@aws-sdk/middleware-flexible-checksums": "^3.973.0",
+        "@aws-sdk/middleware-host-header": "^3.972.5",
+        "@aws-sdk/middleware-location-constraint": "^3.972.5",
+        "@aws-sdk/middleware-logger": "^3.972.5",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.14",
+        "@aws-sdk/middleware-ssec": "^3.972.5",
+        "@aws-sdk/middleware-user-agent": "^3.972.14",
+        "@aws-sdk/region-config-resolver": "^3.972.5",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.2",
+        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/util-endpoints": "^3.996.2",
+        "@aws-sdk/util-user-agent-browser": "^3.972.5",
+        "@aws-sdk/util-user-agent-node": "^3.972.13",
         "@smithy/config-resolver": "^4.4.9",
         "@smithy/core": "^3.23.6",
         "@smithy/eventstream-serde-browser": "^4.2.10",
@@ -452,24 +452,24 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.999.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.999.0.tgz",
-      "integrity": "sha512-HOuEkNng/ZnkN2OQ0LxCl92hhIviQ/cKVvFj4S7NxLYG/Rc652qyysOtzTbg3QM+cG4rimuIzBG5uTlYFSti6A==",
+      "version": "3.998.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.998.0.tgz",
+      "integrity": "sha512-EygieZw6CwTMBoqfP0PDm1QOWunn/W2UEwAA8Wpqq3JWyPHWSXzr7b9wMFcvy92OhGoQfSoeKHkJBvYjaitx4g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/credential-provider-node": "^3.972.14",
-        "@aws-sdk/middleware-host-header": "^3.972.6",
-        "@aws-sdk/middleware-logger": "^3.972.6",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
-        "@aws-sdk/middleware-user-agent": "^3.972.15",
-        "@aws-sdk/region-config-resolver": "^3.972.6",
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/util-endpoints": "^3.996.3",
-        "@aws-sdk/util-user-agent-browser": "^3.972.6",
-        "@aws-sdk/util-user-agent-node": "^3.973.0",
+        "@aws-sdk/core": "^3.973.14",
+        "@aws-sdk/credential-provider-node": "^3.972.13",
+        "@aws-sdk/middleware-host-header": "^3.972.5",
+        "@aws-sdk/middleware-logger": "^3.972.5",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
+        "@aws-sdk/middleware-user-agent": "^3.972.14",
+        "@aws-sdk/region-config-resolver": "^3.972.5",
+        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/util-endpoints": "^3.996.2",
+        "@aws-sdk/util-user-agent-browser": "^3.972.5",
+        "@aws-sdk/util-user-agent-node": "^3.972.13",
         "@smithy/config-resolver": "^4.4.9",
         "@smithy/core": "^3.23.6",
         "@smithy/fetch-http-handler": "^5.3.11",
@@ -502,25 +502,25 @@
       }
     },
     "node_modules/@aws-sdk/client-sesv2": {
-      "version": "3.999.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.999.0.tgz",
-      "integrity": "sha512-TQMIymgZv0T8/+/BhpR+4ctXHosBywl6lSLLO8++nmqRzssCzlGAsgon8pYGWrlnMjiRIcDNwRlXKpsiSxcr1A==",
+      "version": "3.998.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.998.0.tgz",
+      "integrity": "sha512-2JXarADzlvFgPwuLhGzlCkIHyWG0vOVLkhp7oA7rcKwGje7ShMZ32DAZpeW0bnM0eLuOCyjoBvuAqpYoTFxjew==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/credential-provider-node": "^3.972.14",
-        "@aws-sdk/middleware-host-header": "^3.972.6",
-        "@aws-sdk/middleware-logger": "^3.972.6",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
-        "@aws-sdk/middleware-user-agent": "^3.972.15",
-        "@aws-sdk/region-config-resolver": "^3.972.6",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.3",
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/util-endpoints": "^3.996.3",
-        "@aws-sdk/util-user-agent-browser": "^3.972.6",
-        "@aws-sdk/util-user-agent-node": "^3.973.0",
+        "@aws-sdk/core": "^3.973.14",
+        "@aws-sdk/credential-provider-node": "^3.972.13",
+        "@aws-sdk/middleware-host-header": "^3.972.5",
+        "@aws-sdk/middleware-logger": "^3.972.5",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
+        "@aws-sdk/middleware-user-agent": "^3.972.14",
+        "@aws-sdk/region-config-resolver": "^3.972.5",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.2",
+        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/util-endpoints": "^3.996.2",
+        "@aws-sdk/util-user-agent-browser": "^3.972.5",
+        "@aws-sdk/util-user-agent-node": "^3.972.13",
         "@smithy/config-resolver": "^4.4.9",
         "@smithy/core": "^3.23.6",
         "@smithy/fetch-http-handler": "^5.3.11",
@@ -553,13 +553,13 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.15.tgz",
-      "integrity": "sha512-AlC0oQ1/mdJ8vCIqu524j5RB7M8i8E24bbkZmya1CuiQxkY7SdIZAyw7NDNMGaNINQFq/8oGRMX0HeOfCVsl/A==",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.14.tgz",
+      "integrity": "sha512-iAQ1jIGESTVjoqNNY9VlsE9FnCz+Hc8s+dgurF6WrgFyVIw+uggH+V102RFhwjRv4dLSSLfzjDwvQnLszov7TQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/xml-builder": "^3.972.8",
+        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/xml-builder": "^3.972.7",
         "@smithy/core": "^3.23.6",
         "@smithy/node-config-provider": "^4.3.10",
         "@smithy/property-provider": "^4.2.10",
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@aws-sdk/crc64-nvme": {
-      "version": "3.972.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.3.tgz",
-      "integrity": "sha512-UExeK+EFiq5LAcbHm96CQLSia+5pvpUVSAsVApscBzayb7/6dJBJKwV4/onsk4VbWSmqxDMcfuTD+pC4RxgZHg==",
+      "version": "3.972.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.2.tgz",
+      "integrity": "sha512-mhTYqkvoC9pm8Lm7KWmH/BDXylzwOTnqqbix4mUG/AODazcigIKRYkzPc2bld6q4h9q1asQCiPC2S1Q6rvSjIQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -590,13 +590,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.13.tgz",
-      "integrity": "sha512-6ljXKIQ22WFKyIs1jbORIkGanySBHaPPTOI4OxACP5WXgbcR0nDYfqNJfXEGwCK7IzHdNbCSFsNKKs0qCexR8Q==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.12.tgz",
+      "integrity": "sha512-WPtj/iAYHHd+NDM6AZoilZwUz0nMaPxbTPGLA7nhyIYRZN2L8trqfbNvm7g/Jr3gzfKp1LpO6AtBTnrhz9WW2g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/core": "^3.973.14",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
@@ -606,13 +606,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.15.tgz",
-      "integrity": "sha512-dJuSTreu/T8f24SHDNTjd7eQ4rabr0TzPh2UTCwYexQtzG3nTDKm1e5eIdhiroTMDkPEJeY+WPkA6F9wod/20A==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.14.tgz",
+      "integrity": "sha512-umtjCicH2o/Fcc8Fu1562UkDyt6gql4czTYVlUfHfAM8S4QEKggzmtHYYYpPfQcjFj1ajyy68ahYSuF67x4ptQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/core": "^3.973.14",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/fetch-http-handler": "^5.3.11",
         "@smithy/node-http-handler": "^4.4.12",
         "@smithy/property-provider": "^4.2.10",
@@ -627,20 +627,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.13.tgz",
-      "integrity": "sha512-JKSoGb7XeabZLBJptpqoZIFbROUIS65NuQnEHGOpuT9GuuZwag2qciKANiDLFiYk4u8nSrJC9JIOnWKVvPVjeA==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.12.tgz",
+      "integrity": "sha512-qjzgnMl6GIBbVeK74jBqSF07+s6kyeZl5R88qjMs302JlqkxE57jkvflDmZ9I017ffEWqIUa9/M4Hfp28qyu1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/credential-provider-env": "^3.972.13",
-        "@aws-sdk/credential-provider-http": "^3.972.15",
-        "@aws-sdk/credential-provider-login": "^3.972.13",
-        "@aws-sdk/credential-provider-process": "^3.972.13",
-        "@aws-sdk/credential-provider-sso": "^3.972.13",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.13",
-        "@aws-sdk/nested-clients": "^3.996.3",
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/core": "^3.973.14",
+        "@aws-sdk/credential-provider-env": "^3.972.12",
+        "@aws-sdk/credential-provider-http": "^3.972.14",
+        "@aws-sdk/credential-provider-login": "^3.972.12",
+        "@aws-sdk/credential-provider-process": "^3.972.12",
+        "@aws-sdk/credential-provider-sso": "^3.972.12",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.12",
+        "@aws-sdk/nested-clients": "^3.996.2",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/credential-provider-imds": "^4.2.10",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
@@ -652,14 +652,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.13.tgz",
-      "integrity": "sha512-RtYcrxdnJHKY8MFQGLltCURcjuMjnaQpAxPE6+/QEdDHHItMKZgabRe/KScX737F9vJMQsmJy9EmMOkCnoC1JQ==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.12.tgz",
+      "integrity": "sha512-AO57y46PzG24bJzxWLk+FYJG6MzxvXoFXnOKnmKUGV43ub4/FS/4Rz7zCC6ThqUotgqEFd30l5LTAd65RP65pg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/nested-clients": "^3.996.3",
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/core": "^3.973.14",
+        "@aws-sdk/nested-clients": "^3.996.2",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
@@ -671,18 +671,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.14.tgz",
-      "integrity": "sha512-WqoC2aliIjQM/L3oFf6j+op/enT2i9Cc4UTxxMEKrJNECkq4/PlKE5BOjSYFcq6G9mz65EFbXJh7zOU4CvjSKQ==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.13.tgz",
+      "integrity": "sha512-ME2sgus+gFRtiudy5Xqj9iT/tj8lHOIGrFgktuO5skJU4EngOvTZ1Hpj8mknrW4FgWXmpWhc88NtEscUuuDpKw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.13",
-        "@aws-sdk/credential-provider-http": "^3.972.15",
-        "@aws-sdk/credential-provider-ini": "^3.972.13",
-        "@aws-sdk/credential-provider-process": "^3.972.13",
-        "@aws-sdk/credential-provider-sso": "^3.972.13",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.13",
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/credential-provider-env": "^3.972.12",
+        "@aws-sdk/credential-provider-http": "^3.972.14",
+        "@aws-sdk/credential-provider-ini": "^3.972.12",
+        "@aws-sdk/credential-provider-process": "^3.972.12",
+        "@aws-sdk/credential-provider-sso": "^3.972.12",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.12",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/credential-provider-imds": "^4.2.10",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
@@ -694,13 +694,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.13.tgz",
-      "integrity": "sha512-rsRG0LQA4VR+jnDyuqtXi2CePYSmfm5GNL9KxiW8DSe25YwJSr06W8TdUfONAC+rjsTI+aIH2rBGG5FjMeANrw==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.12.tgz",
+      "integrity": "sha512-msxrHBpVP5AOIDohNPCINUtL47f7XI1TEru3N13uM3nWUMvIRA1vFa8Tlxbxm1EntPPvLAxRmvE5EbjDjOZkbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/core": "^3.973.14",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
         "@smithy/types": "^4.13.0",
@@ -711,15 +711,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.13.tgz",
-      "integrity": "sha512-fr0UU1wx8kNHDhTQBXioc/YviSW8iXuAxHvnH7eQUtn8F8o/FU3uu6EUMvAQgyvn7Ne5QFnC0Cj0BFlwCk+RFw==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.12.tgz",
+      "integrity": "sha512-D5iC5546hJyhobJN0szOT4KVeJQ8z/meZq2B3lEDZFcvHONKw+tzq36DAJUy3qLTueeB2geSxiHXngQlA11eoA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/nested-clients": "^3.996.3",
-        "@aws-sdk/token-providers": "3.999.0",
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/core": "^3.973.14",
+        "@aws-sdk/nested-clients": "^3.996.2",
+        "@aws-sdk/token-providers": "3.998.0",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
         "@smithy/types": "^4.13.0",
@@ -730,14 +730,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.13.tgz",
-      "integrity": "sha512-a6iFMh1pgUH0TdcouBppLJUfPM7Yd3R9S1xFodPtCRoLqCz2RQFA3qjA8x4112PVYXEd4/pHX2eihapq39w0rA==",
+      "version": "3.972.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.12.tgz",
+      "integrity": "sha512-yluBahBVsduoA/zgV0NAXtwwXvQ6tNn95dNA3Hg+vISdiPWA46QY0d9PLO2KpNbjtm+1oGcWxemS4fYTwJ0W1w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/nested-clients": "^3.996.3",
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/core": "^3.973.14",
+        "@aws-sdk/nested-clients": "^3.996.2",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
         "@smithy/types": "^4.13.0",
@@ -748,12 +748,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.6.tgz",
-      "integrity": "sha512-3H2bhvb7Cb/S6WFsBy/Dy9q2aegC9JmGH1inO8Lb2sWirSqpLJlZmvQHPE29h2tIxzv6el/14X/tLCQ8BQU6ZQ==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.5.tgz",
+      "integrity": "sha512-4+PMX1vuPoALVhuyW7M2GkV9XrkUeuqhuXPs1IkGo2/5dFM8TxM7gnB/evSNVF/o6NXwnO4Sc+6UtGCDhI6RLg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "^3.973.3",
         "@aws-sdk/util-arn-parser": "^3.972.2",
         "@smithy/node-config-provider": "^4.3.10",
         "@smithy/protocol-http": "^5.3.10",
@@ -766,12 +766,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.6.tgz",
-      "integrity": "sha512-QMdffpU+GkSGC+bz6WdqlclqIeCsOfgX8JFZ5xvwDtX+UTj4mIXm3uXu7Ko6dBseRcJz1FA6T9OmlAAY6JgJUg==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.5.tgz",
+      "integrity": "sha512-8dM11mmRZ8ZrDdkBL5q7Rslhua/nASrUhis2BJuwz2hJ+QsyyuOtr2vvc83fM91YXq18oe26bZI9tboroSo4NA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
@@ -781,17 +781,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.973.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.973.1.tgz",
-      "integrity": "sha512-QLXsxsI6VW8LuGK+/yx699wzqP/NMCGk/hSGP+qtB+Lcff+23UlbahyouLlk+nfT7Iu021SkXBhnAuVd6IZcPw==",
+      "version": "3.973.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.973.0.tgz",
+      "integrity": "sha512-RAYonYq4Tk93fB+QlLlCEaB1nHSM4lTWq4KBJ7s5bh6y30uGaVTmFELSeWlfLVJipyJ/T1FBWmrYETMcNsESoQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/crc64-nvme": "^3.972.3",
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/core": "^3.973.14",
+        "@aws-sdk/crc64-nvme": "^3.972.2",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/is-array-buffer": "^4.2.1",
         "@smithy/node-config-provider": "^4.3.10",
         "@smithy/protocol-http": "^5.3.10",
@@ -806,12 +806,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.6.tgz",
-      "integrity": "sha512-5XHwjPH1lHB+1q4bfC7T8Z5zZrZXfaLcjSMwTd1HPSPrCmPFMbg3UQ5vgNWcVj0xoX4HWqTGkSf2byrjlnRg5w==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.5.tgz",
+      "integrity": "sha512-dVA0m1cEQ2iA6yB19aHvWNeUVTuvTt3AXzT0aiIu2uxk0S7AcmwDCDaRgYa/v+eFHcJVxEnpYTozqA7X62xinw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
@@ -821,12 +821,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.6.tgz",
-      "integrity": "sha512-XdZ2TLwyj3Am6kvUc67vquQvs6+D8npXvXgyEUJAdkUDx5oMFJKOqpK+UpJhVDsEL068WAJl2NEGzbSik7dGJQ==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.5.tgz",
+      "integrity": "sha512-BC8MQUaG78oEGOjDdyGBLQCbio/KNeeMcbN8GZumW6yowe5MHyt//FJr8sipA1/hLOZ++lfpGk9bdaSo7LUpOw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -835,12 +835,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.6.tgz",
-      "integrity": "sha512-iFnaMFMQdljAPrvsCVKYltPt2j40LQqukAbXvW7v0aL5I+1GO7bZ/W8m12WxW3gwyK5p5u1WlHg8TSAizC5cZw==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.5.tgz",
+      "integrity": "sha512-03RqplLZjUTkYi0dDPR/bbOLnDLFNdaVvNENgA3XK7Ph1MhEBhUYlgoGfOyRAKApDZ+WG4ykOoA8jI8J04jmFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -849,12 +849,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.6.tgz",
-      "integrity": "sha512-dY4v3of5EEMvik6+UDwQ96KfUFDk8m1oZDdkSc5lwi4o7rFrjnv0A+yTV+gu230iybQZnKgDLg/rt2P3H+Vscw==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.5.tgz",
+      "integrity": "sha512-2QSuuVkpHTe84+mDdnFjHX8rAP3g0yYwLVAhS3lQN1rW5Z/zNsf8/pYQrLjLO4n4sPCsUAkTa0Vrod0lk+o1Tg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "^3.973.3",
         "@aws/lambda-invoke-store": "^0.2.2",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/types": "^4.13.0",
@@ -865,13 +865,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.15.tgz",
-      "integrity": "sha512-WDLgssevOU5BFx1s8jA7jj6cE5HuImz28sy9jKOaVtz0AW1lYqSzotzdyiybFaBcQTs5zxXOb2pUfyMxgEKY3Q==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.14.tgz",
+      "integrity": "sha512-qnNWgL2WLZbWQmrr+yB23ivo/L7POJxxFlQxhfDGM/NQ4OfG7YORtqwLps0mOMI8pH22kVeoNu+PB8cgRXLoqQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/core": "^3.973.14",
+        "@aws-sdk/types": "^3.973.3",
         "@aws-sdk/util-arn-parser": "^3.972.2",
         "@smithy/core": "^3.23.6",
         "@smithy/node-config-provider": "^4.3.10",
@@ -890,12 +890,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.6.tgz",
-      "integrity": "sha512-acvMUX9jF4I2Ew+Z/EA6gfaFaz9ehci5wxBmXCZeulLuv8m+iGf6pY9uKz8TPjg39bdAz3hxoE0eLP8Qz+IYlA==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.5.tgz",
+      "integrity": "sha512-AfQgwVjK071d1F75jX49CE5KJTlAWwMKqHJoGzf8nUD04iSHw+93rzKSGAFHu3v06k32algI6pF+ctqV/Fjc1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -904,14 +904,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.15",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.15.tgz",
-      "integrity": "sha512-ABlFVcIMmuRAwBT+8q5abAxOr7WmaINirDJBnqGY5b5jSDo00UMlg/G4a0xoAgwm6oAECeJcwkvDlxDwKf58fQ==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.14.tgz",
+      "integrity": "sha512-PzDz+yRAQuIzd+4ZY3s6/TYRzlNKAn4Gae3E5uLV7NnYHqrZHFoAfKE4beXcu3C51pA2/FQ3X2qOGSYqUoN1WQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/core": "^3.973.14",
+        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/util-endpoints": "^3.996.2",
         "@smithy/core": "^3.23.6",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/types": "^4.13.0",
@@ -922,23 +922,23 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.3.tgz",
-      "integrity": "sha512-AU5TY1V29xqwg/MxmA2odwysTez+ccFAhmfRJk+QZT5HNv90UTA9qKd1J9THlsQkvmH7HWTEV1lDNxkQO5PzNw==",
+      "version": "3.996.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.2.tgz",
+      "integrity": "sha512-W+u6EM8WRxOIhAhR2mXMHSaUygqItpTehkgxLwJngXqr9RlAR4t6CtECH7o7QK0ct3oyi5Z8ViDHtPbel+D2Rg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/middleware-host-header": "^3.972.6",
-        "@aws-sdk/middleware-logger": "^3.972.6",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
-        "@aws-sdk/middleware-user-agent": "^3.972.15",
-        "@aws-sdk/region-config-resolver": "^3.972.6",
-        "@aws-sdk/types": "^3.973.4",
-        "@aws-sdk/util-endpoints": "^3.996.3",
-        "@aws-sdk/util-user-agent-browser": "^3.972.6",
-        "@aws-sdk/util-user-agent-node": "^3.973.0",
+        "@aws-sdk/core": "^3.973.14",
+        "@aws-sdk/middleware-host-header": "^3.972.5",
+        "@aws-sdk/middleware-logger": "^3.972.5",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
+        "@aws-sdk/middleware-user-agent": "^3.972.14",
+        "@aws-sdk/region-config-resolver": "^3.972.5",
+        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/util-endpoints": "^3.996.2",
+        "@aws-sdk/util-user-agent-browser": "^3.972.5",
+        "@aws-sdk/util-user-agent-node": "^3.972.13",
         "@smithy/config-resolver": "^4.4.9",
         "@smithy/core": "^3.23.6",
         "@smithy/fetch-http-handler": "^5.3.11",
@@ -971,12 +971,12 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.6.tgz",
-      "integrity": "sha512-Aa5PusHLXAqLTX1UKDvI3pHQJtIsF7Q+3turCHqfz/1F61/zDMWfbTC8evjhrrYVAtz9Vsv3SJ/waSUeu7B6gw==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.5.tgz",
+      "integrity": "sha512-AOitrygDwfTNCLCW7L+GScDy1p49FZ6WutTUFWROouoPetfVNmpL4q8TWD3MhfY/ynhoGhleUQENrBH374EU8w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/config-resolver": "^4.4.9",
         "@smithy/node-config-provider": "^4.3.10",
         "@smithy/types": "^4.13.0",
@@ -987,13 +987,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.3.tgz",
-      "integrity": "sha512-gQYI/Buwp0CAGQxY7mR5VzkP56rkWq2Y1ROkFuXh5XY94DsSjJw62B3I0N0lysQmtwiL2ht2KHI9NylM/RP4FA==",
+      "version": "3.996.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.2.tgz",
+      "integrity": "sha512-fUWHKtgeTfTEML5gi3yugy7caaoe7/8YdM/H0gQXuSDYNL3hORyGST5RyLnhfVDeNgypANLpIP6wzzIq74kEwQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.15",
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.14",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/signature-v4": "^5.3.10",
         "@smithy/types": "^4.13.0",
@@ -1004,14 +1004,14 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.999.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.999.0.tgz",
-      "integrity": "sha512-cx0hHUlgXULfykx4rdu/ciNAJaa3AL5xz3rieCz7NKJ68MJwlj3664Y8WR5MGgxfyYJBdamnkjNSx5Kekuc0cg==",
+      "version": "3.998.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.998.0.tgz",
+      "integrity": "sha512-JFzi44tQnENZQ+1DYcHfoa/wTRKkccz0VsNMow0rvsxZtqUEkeV2pYFbir35mHTyUKju9995ay1MAGxLt1dpRA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.15",
-        "@aws-sdk/nested-clients": "^3.996.3",
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/core": "^3.973.14",
+        "@aws-sdk/nested-clients": "^3.996.2",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
         "@smithy/types": "^4.13.0",
@@ -1022,9 +1022,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.4.tgz",
-      "integrity": "sha512-RW60aH26Bsc016Y9B98hC0Plx6fK5P2v/iQYwMzrSjiDh1qRMUCP6KrXHYEHe3uFvKiOC93Z9zk4BJsUi6Tj1Q==",
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.3.tgz",
+      "integrity": "sha512-tma6D8/xHZHJEUqmr6ksZjZ0onyIUqKDQLyp50ttZJmS0IwFYzxBgp5CxFvpYAnah52V3UtgrqGA6E83gtT7NQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -1036,8 +1036,6 @@
     },
     "node_modules/@aws-sdk/util-arn-parser": {
       "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.2.tgz",
-      "integrity": "sha512-VkykWbqMjlSgBFDyrY3nOSqupMc6ivXuGmvci6Q3NnLq5kC+mKQe2QBZ4nrWRE/jqOxeFP2uYzLtwncYYcvQDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1047,12 +1045,12 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.3.tgz",
-      "integrity": "sha512-yWIQSNiCjykLL+ezN5A+DfBb1gfXTytBxm57e64lYmwxDHNmInYHRJYYRAGWG1o77vKEiWaw4ui28e3yb1k5aQ==",
+      "version": "3.996.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.2.tgz",
+      "integrity": "sha512-83E6T1CKi0/IozPzqRBKqduW0mS4UQdI3soBH6CG7UgupTADWunqEMOTuPWCs9XGjpJJ4ujj+yu7pn8svhp5yg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/types": "^4.13.0",
         "@smithy/url-parser": "^4.2.10",
         "@smithy/util-endpoints": "^3.3.1",
@@ -1073,25 +1071,25 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.6.tgz",
-      "integrity": "sha512-Fwr/llD6GOrFgQnKaI2glhohdGuBDfHfora6iG9qsBBBR8xv1SdCSwbtf5CWlUdCw5X7g76G/9Hf0Inh0EmoxA==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.5.tgz",
+      "integrity": "sha512-2ja1WqtuBaEAMgVoHYuWx393DF6ULqdt3OozeO7BosqouYaoU47Adtp9vEF+GImSG/Q8A+dqfwDULTTdMkHGUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/types": "^4.13.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.0.tgz",
-      "integrity": "sha512-A9J2G4Nf236e9GpaC1JnA8wRn6u6GjnOXiTwBLA6NUJhlBTIGfrTy+K1IazmF8y+4OFdW3O5TZlhyspJMqiqjA==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.13.tgz",
+      "integrity": "sha512-PHErmuu+v6iAST48zcsB2cYwDKW45gk6qCp49t1p0NGZ4EaFPr/tA5jl0X/ekDwvWbuT0LTj++fjjdVQAbuh0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.15",
-        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/middleware-user-agent": "^3.972.14",
+        "@aws-sdk/types": "^3.973.3",
         "@smithy/node-config-provider": "^4.3.10",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
@@ -1109,9 +1107,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.8.tgz",
-      "integrity": "sha512-Ql8elcUdYCha83Ol7NznBsgN5GVZnv3vUd86fEc6waU6oUdY0T1O9NODkEEOS/Uaogr87avDrUC6DSeM4oXjZg==",
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.7.tgz",
+      "integrity": "sha512-9GF86s6mHuc1TYCbuKatMDWl2PyK3KIkpRaI7ul2/gYZPfaLzKZ+ISHhxzVb9KVeakf75tUQe6CXW2gugSCXNw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -1124,8 +1122,6 @@
     },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
-      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -7428,9 +7424,7 @@
       "optional": true
     },
     "node_modules/bowser": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "version": "2.13.1",
       "license": "MIT"
     },
     "node_modules/boxen": {
@@ -8259,13 +8253,13 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "mdn-data": "2.12.2",
+        "mdn-data": "2.0.30",
         "source-map-js": "^1.0.1"
       },
       "engines": {
@@ -11722,9 +11716,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "license": "CC0-1.0",
       "optional": true
     },
@@ -13634,6 +13628,63 @@
         "postcss": "^8.4.32"
       }
     },
+    "node_modules/postcss-svgo/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/postcss-svgo/node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/postcss-svgo/node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "license": "CC0-1.0",
+      "optional": true
+    },
+    "node_modules/postcss-svgo/node_modules/svgo": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
+      "integrity": "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "svgo": "bin/svgo.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
     "node_modules/postcss-unique-selectors": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.4.tgz",
@@ -15157,25 +15208,25 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
-      "integrity": "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
+      "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "commander": "^11.1.0",
+        "@trysound/sax": "0.2.0",
+        "commander": "^7.2.0",
         "css-select": "^5.1.0",
-        "css-tree": "^3.0.1",
+        "css-tree": "^2.3.1",
         "css-what": "^6.1.0",
         "csso": "^5.0.5",
-        "picocolors": "^1.1.1",
-        "sax": "^1.4.1"
+        "picocolors": "^1.0.0"
       },
       "bin": {
-        "svgo": "bin/svgo.js"
+        "svgo": "bin/svgo"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=14.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -15183,13 +15234,13 @@
       }
     },
     "node_modules/svgo/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">=16"
+        "node": ">= 10"
       }
     },
     "node_modules/swagger-ui-dist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8259,13 +8259,13 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "mdn-data": "2.0.30",
+        "mdn-data": "2.12.2",
         "source-map-js": "^1.0.1"
       },
       "engines": {
@@ -11722,9 +11722,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "license": "CC0-1.0",
       "optional": true
     },
@@ -13634,63 +13634,6 @@
         "postcss": "^8.4.32"
       }
     },
-    "node_modules/postcss-svgo/node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/postcss-svgo/node_modules/css-tree": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
-      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mdn-data": "2.12.2",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
-    "node_modules/postcss-svgo/node_modules/mdn-data": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
-      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "license": "CC0-1.0",
-      "optional": true
-    },
-    "node_modules/postcss-svgo/node_modules/svgo": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
-      "integrity": "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "commander": "^11.1.0",
-        "css-select": "^5.1.0",
-        "css-tree": "^3.0.1",
-        "css-what": "^6.1.0",
-        "csso": "^5.0.5",
-        "picocolors": "^1.1.1",
-        "sax": "^1.4.1"
-      },
-      "bin": {
-        "svgo": "bin/svgo.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/svgo"
-      }
-    },
     "node_modules/postcss-unique-selectors": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.4.tgz",
@@ -15214,25 +15157,25 @@
       }
     },
     "node_modules/svgo": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
-      "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
+      "integrity": "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
+        "commander": "^11.1.0",
         "css-select": "^5.1.0",
-        "css-tree": "^2.3.1",
+        "css-tree": "^3.0.1",
         "css-what": "^6.1.0",
         "csso": "^5.0.5",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.1.1",
+        "sax": "^1.4.1"
       },
       "bin": {
-        "svgo": "bin/svgo"
+        "svgo": "bin/svgo.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=16"
       },
       "funding": {
         "type": "opencollective",
@@ -15240,13 +15183,13 @@
       }
     },
     "node_modules/svgo/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">= 10"
+        "node": ">=16"
       }
     },
     "node_modules/swagger-ui-dist": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -386,32 +386,32 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.998.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.998.0.tgz",
-      "integrity": "sha512-XkJ6GN+egutEHSa9+t4OngCRyyP6Zl+4FX+hN7rDqlLjPuK++NHdMVrRSaVq1/H1m0+Nif0Rtz1BiTYP/htmvg==",
+      "version": "3.999.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.999.0.tgz",
+      "integrity": "sha512-6ML2ls4nnOxm1kKzy2RgM+i8aS/9wgw6V91iqSibBYU/isYs8BvC2xcv8AsaWG5mOQjytjRzsBO5COxfWVPg3A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/credential-provider-node": "^3.972.13",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.5",
-        "@aws-sdk/middleware-expect-continue": "^3.972.5",
-        "@aws-sdk/middleware-flexible-checksums": "^3.973.0",
-        "@aws-sdk/middleware-host-header": "^3.972.5",
-        "@aws-sdk/middleware-location-constraint": "^3.972.5",
-        "@aws-sdk/middleware-logger": "^3.972.5",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.14",
-        "@aws-sdk/middleware-ssec": "^3.972.5",
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/region-config-resolver": "^3.972.5",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.2",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
-        "@aws-sdk/util-user-agent-browser": "^3.972.5",
-        "@aws-sdk/util-user-agent-node": "^3.972.13",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/credential-provider-node": "^3.972.14",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.6",
+        "@aws-sdk/middleware-expect-continue": "^3.972.6",
+        "@aws-sdk/middleware-flexible-checksums": "^3.973.1",
+        "@aws-sdk/middleware-host-header": "^3.972.6",
+        "@aws-sdk/middleware-location-constraint": "^3.972.6",
+        "@aws-sdk/middleware-logger": "^3.972.6",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.15",
+        "@aws-sdk/middleware-ssec": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.15",
+        "@aws-sdk/region-config-resolver": "^3.972.6",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.3",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/util-user-agent-browser": "^3.972.6",
+        "@aws-sdk/util-user-agent-node": "^3.973.0",
         "@smithy/config-resolver": "^4.4.9",
         "@smithy/core": "^3.23.6",
         "@smithy/eventstream-serde-browser": "^4.2.10",
@@ -452,24 +452,24 @@
       }
     },
     "node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.998.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.998.0.tgz",
-      "integrity": "sha512-EygieZw6CwTMBoqfP0PDm1QOWunn/W2UEwAA8Wpqq3JWyPHWSXzr7b9wMFcvy92OhGoQfSoeKHkJBvYjaitx4g==",
+      "version": "3.999.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.999.0.tgz",
+      "integrity": "sha512-HOuEkNng/ZnkN2OQ0LxCl92hhIviQ/cKVvFj4S7NxLYG/Rc652qyysOtzTbg3QM+cG4rimuIzBG5uTlYFSti6A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/credential-provider-node": "^3.972.13",
-        "@aws-sdk/middleware-host-header": "^3.972.5",
-        "@aws-sdk/middleware-logger": "^3.972.5",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/region-config-resolver": "^3.972.5",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
-        "@aws-sdk/util-user-agent-browser": "^3.972.5",
-        "@aws-sdk/util-user-agent-node": "^3.972.13",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/credential-provider-node": "^3.972.14",
+        "@aws-sdk/middleware-host-header": "^3.972.6",
+        "@aws-sdk/middleware-logger": "^3.972.6",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.15",
+        "@aws-sdk/region-config-resolver": "^3.972.6",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/util-user-agent-browser": "^3.972.6",
+        "@aws-sdk/util-user-agent-node": "^3.973.0",
         "@smithy/config-resolver": "^4.4.9",
         "@smithy/core": "^3.23.6",
         "@smithy/fetch-http-handler": "^5.3.11",
@@ -502,25 +502,25 @@
       }
     },
     "node_modules/@aws-sdk/client-sesv2": {
-      "version": "3.998.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.998.0.tgz",
-      "integrity": "sha512-2JXarADzlvFgPwuLhGzlCkIHyWG0vOVLkhp7oA7rcKwGje7ShMZ32DAZpeW0bnM0eLuOCyjoBvuAqpYoTFxjew==",
+      "version": "3.999.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.999.0.tgz",
+      "integrity": "sha512-TQMIymgZv0T8/+/BhpR+4ctXHosBywl6lSLLO8++nmqRzssCzlGAsgon8pYGWrlnMjiRIcDNwRlXKpsiSxcr1A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/credential-provider-node": "^3.972.13",
-        "@aws-sdk/middleware-host-header": "^3.972.5",
-        "@aws-sdk/middleware-logger": "^3.972.5",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/region-config-resolver": "^3.972.5",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.2",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
-        "@aws-sdk/util-user-agent-browser": "^3.972.5",
-        "@aws-sdk/util-user-agent-node": "^3.972.13",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/credential-provider-node": "^3.972.14",
+        "@aws-sdk/middleware-host-header": "^3.972.6",
+        "@aws-sdk/middleware-logger": "^3.972.6",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.15",
+        "@aws-sdk/region-config-resolver": "^3.972.6",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.3",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/util-user-agent-browser": "^3.972.6",
+        "@aws-sdk/util-user-agent-node": "^3.973.0",
         "@smithy/config-resolver": "^4.4.9",
         "@smithy/core": "^3.23.6",
         "@smithy/fetch-http-handler": "^5.3.11",
@@ -553,13 +553,13 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.973.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.14.tgz",
-      "integrity": "sha512-iAQ1jIGESTVjoqNNY9VlsE9FnCz+Hc8s+dgurF6WrgFyVIw+uggH+V102RFhwjRv4dLSSLfzjDwvQnLszov7TQ==",
+      "version": "3.973.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.15.tgz",
+      "integrity": "sha512-AlC0oQ1/mdJ8vCIqu524j5RB7M8i8E24bbkZmya1CuiQxkY7SdIZAyw7NDNMGaNINQFq/8oGRMX0HeOfCVsl/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/xml-builder": "^3.972.7",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/xml-builder": "^3.972.8",
         "@smithy/core": "^3.23.6",
         "@smithy/node-config-provider": "^4.3.10",
         "@smithy/property-provider": "^4.2.10",
@@ -577,9 +577,9 @@
       }
     },
     "node_modules/@aws-sdk/crc64-nvme": {
-      "version": "3.972.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.2.tgz",
-      "integrity": "sha512-mhTYqkvoC9pm8Lm7KWmH/BDXylzwOTnqqbix4mUG/AODazcigIKRYkzPc2bld6q4h9q1asQCiPC2S1Q6rvSjIQ==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.3.tgz",
+      "integrity": "sha512-UExeK+EFiq5LAcbHm96CQLSia+5pvpUVSAsVApscBzayb7/6dJBJKwV4/onsk4VbWSmqxDMcfuTD+pC4RxgZHg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -590,13 +590,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.12.tgz",
-      "integrity": "sha512-WPtj/iAYHHd+NDM6AZoilZwUz0nMaPxbTPGLA7nhyIYRZN2L8trqfbNvm7g/Jr3gzfKp1LpO6AtBTnrhz9WW2g==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.13.tgz",
+      "integrity": "sha512-6ljXKIQ22WFKyIs1jbORIkGanySBHaPPTOI4OxACP5WXgbcR0nDYfqNJfXEGwCK7IzHdNbCSFsNKKs0qCexR8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
@@ -606,13 +606,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.14.tgz",
-      "integrity": "sha512-umtjCicH2o/Fcc8Fu1562UkDyt6gql4czTYVlUfHfAM8S4QEKggzmtHYYYpPfQcjFj1ajyy68ahYSuF67x4ptQ==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.15.tgz",
+      "integrity": "sha512-dJuSTreu/T8f24SHDNTjd7eQ4rabr0TzPh2UTCwYexQtzG3nTDKm1e5eIdhiroTMDkPEJeY+WPkA6F9wod/20A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/fetch-http-handler": "^5.3.11",
         "@smithy/node-http-handler": "^4.4.12",
         "@smithy/property-provider": "^4.2.10",
@@ -627,20 +627,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.12.tgz",
-      "integrity": "sha512-qjzgnMl6GIBbVeK74jBqSF07+s6kyeZl5R88qjMs302JlqkxE57jkvflDmZ9I017ffEWqIUa9/M4Hfp28qyu1g==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.13.tgz",
+      "integrity": "sha512-JKSoGb7XeabZLBJptpqoZIFbROUIS65NuQnEHGOpuT9GuuZwag2qciKANiDLFiYk4u8nSrJC9JIOnWKVvPVjeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/credential-provider-env": "^3.972.12",
-        "@aws-sdk/credential-provider-http": "^3.972.14",
-        "@aws-sdk/credential-provider-login": "^3.972.12",
-        "@aws-sdk/credential-provider-process": "^3.972.12",
-        "@aws-sdk/credential-provider-sso": "^3.972.12",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.12",
-        "@aws-sdk/nested-clients": "^3.996.2",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/credential-provider-env": "^3.972.13",
+        "@aws-sdk/credential-provider-http": "^3.972.15",
+        "@aws-sdk/credential-provider-login": "^3.972.13",
+        "@aws-sdk/credential-provider-process": "^3.972.13",
+        "@aws-sdk/credential-provider-sso": "^3.972.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.13",
+        "@aws-sdk/nested-clients": "^3.996.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/credential-provider-imds": "^4.2.10",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
@@ -652,14 +652,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.12.tgz",
-      "integrity": "sha512-AO57y46PzG24bJzxWLk+FYJG6MzxvXoFXnOKnmKUGV43ub4/FS/4Rz7zCC6ThqUotgqEFd30l5LTAd65RP65pg==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.13.tgz",
+      "integrity": "sha512-RtYcrxdnJHKY8MFQGLltCURcjuMjnaQpAxPE6+/QEdDHHItMKZgabRe/KScX737F9vJMQsmJy9EmMOkCnoC1JQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/nested-clients": "^3.996.2",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/nested-clients": "^3.996.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
@@ -671,18 +671,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.13.tgz",
-      "integrity": "sha512-ME2sgus+gFRtiudy5Xqj9iT/tj8lHOIGrFgktuO5skJU4EngOvTZ1Hpj8mknrW4FgWXmpWhc88NtEscUuuDpKw==",
+      "version": "3.972.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.14.tgz",
+      "integrity": "sha512-WqoC2aliIjQM/L3oFf6j+op/enT2i9Cc4UTxxMEKrJNECkq4/PlKE5BOjSYFcq6G9mz65EFbXJh7zOU4CvjSKQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.12",
-        "@aws-sdk/credential-provider-http": "^3.972.14",
-        "@aws-sdk/credential-provider-ini": "^3.972.12",
-        "@aws-sdk/credential-provider-process": "^3.972.12",
-        "@aws-sdk/credential-provider-sso": "^3.972.12",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.12",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/credential-provider-env": "^3.972.13",
+        "@aws-sdk/credential-provider-http": "^3.972.15",
+        "@aws-sdk/credential-provider-ini": "^3.972.13",
+        "@aws-sdk/credential-provider-process": "^3.972.13",
+        "@aws-sdk/credential-provider-sso": "^3.972.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.13",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/credential-provider-imds": "^4.2.10",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
@@ -694,13 +694,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.12.tgz",
-      "integrity": "sha512-msxrHBpVP5AOIDohNPCINUtL47f7XI1TEru3N13uM3nWUMvIRA1vFa8Tlxbxm1EntPPvLAxRmvE5EbjDjOZkbw==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.13.tgz",
+      "integrity": "sha512-rsRG0LQA4VR+jnDyuqtXi2CePYSmfm5GNL9KxiW8DSe25YwJSr06W8TdUfONAC+rjsTI+aIH2rBGG5FjMeANrw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
         "@smithy/types": "^4.13.0",
@@ -711,15 +711,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.12.tgz",
-      "integrity": "sha512-D5iC5546hJyhobJN0szOT4KVeJQ8z/meZq2B3lEDZFcvHONKw+tzq36DAJUy3qLTueeB2geSxiHXngQlA11eoA==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.13.tgz",
+      "integrity": "sha512-fr0UU1wx8kNHDhTQBXioc/YviSW8iXuAxHvnH7eQUtn8F8o/FU3uu6EUMvAQgyvn7Ne5QFnC0Cj0BFlwCk+RFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/nested-clients": "^3.996.2",
-        "@aws-sdk/token-providers": "3.998.0",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/nested-clients": "^3.996.3",
+        "@aws-sdk/token-providers": "3.999.0",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
         "@smithy/types": "^4.13.0",
@@ -730,14 +730,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.12.tgz",
-      "integrity": "sha512-yluBahBVsduoA/zgV0NAXtwwXvQ6tNn95dNA3Hg+vISdiPWA46QY0d9PLO2KpNbjtm+1oGcWxemS4fYTwJ0W1w==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.13.tgz",
+      "integrity": "sha512-a6iFMh1pgUH0TdcouBppLJUfPM7Yd3R9S1xFodPtCRoLqCz2RQFA3qjA8x4112PVYXEd4/pHX2eihapq39w0rA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/nested-clients": "^3.996.2",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/nested-clients": "^3.996.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
         "@smithy/types": "^4.13.0",
@@ -748,12 +748,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.5.tgz",
-      "integrity": "sha512-4+PMX1vuPoALVhuyW7M2GkV9XrkUeuqhuXPs1IkGo2/5dFM8TxM7gnB/evSNVF/o6NXwnO4Sc+6UtGCDhI6RLg==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.6.tgz",
+      "integrity": "sha512-3H2bhvb7Cb/S6WFsBy/Dy9q2aegC9JmGH1inO8Lb2sWirSqpLJlZmvQHPE29h2tIxzv6el/14X/tLCQ8BQU6ZQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@aws-sdk/util-arn-parser": "^3.972.2",
         "@smithy/node-config-provider": "^4.3.10",
         "@smithy/protocol-http": "^5.3.10",
@@ -766,12 +766,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.5.tgz",
-      "integrity": "sha512-8dM11mmRZ8ZrDdkBL5q7Rslhua/nASrUhis2BJuwz2hJ+QsyyuOtr2vvc83fM91YXq18oe26bZI9tboroSo4NA==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.6.tgz",
+      "integrity": "sha512-QMdffpU+GkSGC+bz6WdqlclqIeCsOfgX8JFZ5xvwDtX+UTj4mIXm3uXu7Ko6dBseRcJz1FA6T9OmlAAY6JgJUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
@@ -781,17 +781,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.973.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.973.0.tgz",
-      "integrity": "sha512-RAYonYq4Tk93fB+QlLlCEaB1nHSM4lTWq4KBJ7s5bh6y30uGaVTmFELSeWlfLVJipyJ/T1FBWmrYETMcNsESoQ==",
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.973.1.tgz",
+      "integrity": "sha512-QLXsxsI6VW8LuGK+/yx699wzqP/NMCGk/hSGP+qtB+Lcff+23UlbahyouLlk+nfT7Iu021SkXBhnAuVd6IZcPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/crc64-nvme": "^3.972.2",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/crc64-nvme": "^3.972.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/is-array-buffer": "^4.2.1",
         "@smithy/node-config-provider": "^4.3.10",
         "@smithy/protocol-http": "^5.3.10",
@@ -806,12 +806,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.5.tgz",
-      "integrity": "sha512-dVA0m1cEQ2iA6yB19aHvWNeUVTuvTt3AXzT0aiIu2uxk0S7AcmwDCDaRgYa/v+eFHcJVxEnpYTozqA7X62xinw==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.6.tgz",
+      "integrity": "sha512-5XHwjPH1lHB+1q4bfC7T8Z5zZrZXfaLcjSMwTd1HPSPrCmPFMbg3UQ5vgNWcVj0xoX4HWqTGkSf2byrjlnRg5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
@@ -821,12 +821,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.5.tgz",
-      "integrity": "sha512-BC8MQUaG78oEGOjDdyGBLQCbio/KNeeMcbN8GZumW6yowe5MHyt//FJr8sipA1/hLOZ++lfpGk9bdaSo7LUpOw==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.6.tgz",
+      "integrity": "sha512-XdZ2TLwyj3Am6kvUc67vquQvs6+D8npXvXgyEUJAdkUDx5oMFJKOqpK+UpJhVDsEL068WAJl2NEGzbSik7dGJQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -835,12 +835,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.5.tgz",
-      "integrity": "sha512-03RqplLZjUTkYi0dDPR/bbOLnDLFNdaVvNENgA3XK7Ph1MhEBhUYlgoGfOyRAKApDZ+WG4ykOoA8jI8J04jmFA==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.6.tgz",
+      "integrity": "sha512-iFnaMFMQdljAPrvsCVKYltPt2j40LQqukAbXvW7v0aL5I+1GO7bZ/W8m12WxW3gwyK5p5u1WlHg8TSAizC5cZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -849,12 +849,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.5.tgz",
-      "integrity": "sha512-2QSuuVkpHTe84+mDdnFjHX8rAP3g0yYwLVAhS3lQN1rW5Z/zNsf8/pYQrLjLO4n4sPCsUAkTa0Vrod0lk+o1Tg==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.6.tgz",
+      "integrity": "sha512-dY4v3of5EEMvik6+UDwQ96KfUFDk8m1oZDdkSc5lwi4o7rFrjnv0A+yTV+gu230iybQZnKgDLg/rt2P3H+Vscw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@aws/lambda-invoke-store": "^0.2.2",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/types": "^4.13.0",
@@ -865,13 +865,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.14.tgz",
-      "integrity": "sha512-qnNWgL2WLZbWQmrr+yB23ivo/L7POJxxFlQxhfDGM/NQ4OfG7YORtqwLps0mOMI8pH22kVeoNu+PB8cgRXLoqQ==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.15.tgz",
+      "integrity": "sha512-WDLgssevOU5BFx1s8jA7jj6cE5HuImz28sy9jKOaVtz0AW1lYqSzotzdyiybFaBcQTs5zxXOb2pUfyMxgEKY3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/types": "^3.973.4",
         "@aws-sdk/util-arn-parser": "^3.972.2",
         "@smithy/core": "^3.23.6",
         "@smithy/node-config-provider": "^4.3.10",
@@ -890,12 +890,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.5.tgz",
-      "integrity": "sha512-AfQgwVjK071d1F75jX49CE5KJTlAWwMKqHJoGzf8nUD04iSHw+93rzKSGAFHu3v06k32algI6pF+ctqV/Fjc1A==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.6.tgz",
+      "integrity": "sha512-acvMUX9jF4I2Ew+Z/EA6gfaFaz9ehci5wxBmXCZeulLuv8m+iGf6pY9uKz8TPjg39bdAz3hxoE0eLP8Qz+IYlA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
       },
@@ -904,14 +904,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.14",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.14.tgz",
-      "integrity": "sha512-PzDz+yRAQuIzd+4ZY3s6/TYRzlNKAn4Gae3E5uLV7NnYHqrZHFoAfKE4beXcu3C51pA2/FQ3X2qOGSYqUoN1WQ==",
+      "version": "3.972.15",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.15.tgz",
+      "integrity": "sha512-ABlFVcIMmuRAwBT+8q5abAxOr7WmaINirDJBnqGY5b5jSDo00UMlg/G4a0xoAgwm6oAECeJcwkvDlxDwKf58fQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
         "@smithy/core": "^3.23.6",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/types": "^4.13.0",
@@ -922,23 +922,23 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.996.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.2.tgz",
-      "integrity": "sha512-W+u6EM8WRxOIhAhR2mXMHSaUygqItpTehkgxLwJngXqr9RlAR4t6CtECH7o7QK0ct3oyi5Z8ViDHtPbel+D2Rg==",
+      "version": "3.996.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.3.tgz",
+      "integrity": "sha512-AU5TY1V29xqwg/MxmA2odwysTez+ccFAhmfRJk+QZT5HNv90UTA9qKd1J9THlsQkvmH7HWTEV1lDNxkQO5PzNw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/middleware-host-header": "^3.972.5",
-        "@aws-sdk/middleware-logger": "^3.972.5",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.5",
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/region-config-resolver": "^3.972.5",
-        "@aws-sdk/types": "^3.973.3",
-        "@aws-sdk/util-endpoints": "^3.996.2",
-        "@aws-sdk/util-user-agent-browser": "^3.972.5",
-        "@aws-sdk/util-user-agent-node": "^3.972.13",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/middleware-host-header": "^3.972.6",
+        "@aws-sdk/middleware-logger": "^3.972.6",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.6",
+        "@aws-sdk/middleware-user-agent": "^3.972.15",
+        "@aws-sdk/region-config-resolver": "^3.972.6",
+        "@aws-sdk/types": "^3.973.4",
+        "@aws-sdk/util-endpoints": "^3.996.3",
+        "@aws-sdk/util-user-agent-browser": "^3.972.6",
+        "@aws-sdk/util-user-agent-node": "^3.973.0",
         "@smithy/config-resolver": "^4.4.9",
         "@smithy/core": "^3.23.6",
         "@smithy/fetch-http-handler": "^5.3.11",
@@ -971,12 +971,12 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.5.tgz",
-      "integrity": "sha512-AOitrygDwfTNCLCW7L+GScDy1p49FZ6WutTUFWROouoPetfVNmpL4q8TWD3MhfY/ynhoGhleUQENrBH374EU8w==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.6.tgz",
+      "integrity": "sha512-Aa5PusHLXAqLTX1UKDvI3pHQJtIsF7Q+3turCHqfz/1F61/zDMWfbTC8evjhrrYVAtz9Vsv3SJ/waSUeu7B6gw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/config-resolver": "^4.4.9",
         "@smithy/node-config-provider": "^4.3.10",
         "@smithy/types": "^4.13.0",
@@ -987,13 +987,13 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.2.tgz",
-      "integrity": "sha512-fUWHKtgeTfTEML5gi3yugy7caaoe7/8YdM/H0gQXuSDYNL3hORyGST5RyLnhfVDeNgypANLpIP6wzzIq74kEwQ==",
+      "version": "3.996.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.3.tgz",
+      "integrity": "sha512-gQYI/Buwp0CAGQxY7mR5VzkP56rkWq2Y1ROkFuXh5XY94DsSjJw62B3I0N0lysQmtwiL2ht2KHI9NylM/RP4FA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.14",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.15",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/protocol-http": "^5.3.10",
         "@smithy/signature-v4": "^5.3.10",
         "@smithy/types": "^4.13.0",
@@ -1004,14 +1004,14 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.998.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.998.0.tgz",
-      "integrity": "sha512-JFzi44tQnENZQ+1DYcHfoa/wTRKkccz0VsNMow0rvsxZtqUEkeV2pYFbir35mHTyUKju9995ay1MAGxLt1dpRA==",
+      "version": "3.999.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.999.0.tgz",
+      "integrity": "sha512-cx0hHUlgXULfykx4rdu/ciNAJaa3AL5xz3rieCz7NKJ68MJwlj3664Y8WR5MGgxfyYJBdamnkjNSx5Kekuc0cg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.14",
-        "@aws-sdk/nested-clients": "^3.996.2",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/core": "^3.973.15",
+        "@aws-sdk/nested-clients": "^3.996.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/property-provider": "^4.2.10",
         "@smithy/shared-ini-file-loader": "^4.4.5",
         "@smithy/types": "^4.13.0",
@@ -1022,9 +1022,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.973.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.3.tgz",
-      "integrity": "sha512-tma6D8/xHZHJEUqmr6ksZjZ0onyIUqKDQLyp50ttZJmS0IwFYzxBgp5CxFvpYAnah52V3UtgrqGA6E83gtT7NQ==",
+      "version": "3.973.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.4.tgz",
+      "integrity": "sha512-RW60aH26Bsc016Y9B98hC0Plx6fK5P2v/iQYwMzrSjiDh1qRMUCP6KrXHYEHe3uFvKiOC93Z9zk4BJsUi6Tj1Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -1036,6 +1036,8 @@
     },
     "node_modules/@aws-sdk/util-arn-parser": {
       "version": "3.972.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.2.tgz",
+      "integrity": "sha512-VkykWbqMjlSgBFDyrY3nOSqupMc6ivXuGmvci6Q3NnLq5kC+mKQe2QBZ4nrWRE/jqOxeFP2uYzLtwncYYcvQDg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1045,12 +1047,12 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.996.2",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.2.tgz",
-      "integrity": "sha512-83E6T1CKi0/IozPzqRBKqduW0mS4UQdI3soBH6CG7UgupTADWunqEMOTuPWCs9XGjpJJ4ujj+yu7pn8svhp5yg==",
+      "version": "3.996.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.3.tgz",
+      "integrity": "sha512-yWIQSNiCjykLL+ezN5A+DfBb1gfXTytBxm57e64lYmwxDHNmInYHRJYYRAGWG1o77vKEiWaw4ui28e3yb1k5aQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/types": "^4.13.0",
         "@smithy/url-parser": "^4.2.10",
         "@smithy/util-endpoints": "^3.3.1",
@@ -1071,25 +1073,25 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.5.tgz",
-      "integrity": "sha512-2ja1WqtuBaEAMgVoHYuWx393DF6ULqdt3OozeO7BosqouYaoU47Adtp9vEF+GImSG/Q8A+dqfwDULTTdMkHGUQ==",
+      "version": "3.972.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.6.tgz",
+      "integrity": "sha512-Fwr/llD6GOrFgQnKaI2glhohdGuBDfHfora6iG9qsBBBR8xv1SdCSwbtf5CWlUdCw5X7g76G/9Hf0Inh0EmoxA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/types": "^4.13.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.972.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.13.tgz",
-      "integrity": "sha512-PHErmuu+v6iAST48zcsB2cYwDKW45gk6qCp49t1p0NGZ4EaFPr/tA5jl0X/ekDwvWbuT0LTj++fjjdVQAbuh0Q==",
+      "version": "3.973.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.0.tgz",
+      "integrity": "sha512-A9J2G4Nf236e9GpaC1JnA8wRn6u6GjnOXiTwBLA6NUJhlBTIGfrTy+K1IazmF8y+4OFdW3O5TZlhyspJMqiqjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "^3.972.14",
-        "@aws-sdk/types": "^3.973.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.15",
+        "@aws-sdk/types": "^3.973.4",
         "@smithy/node-config-provider": "^4.3.10",
         "@smithy/types": "^4.13.0",
         "tslib": "^2.6.2"
@@ -1107,9 +1109,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.7.tgz",
-      "integrity": "sha512-9GF86s6mHuc1TYCbuKatMDWl2PyK3KIkpRaI7ul2/gYZPfaLzKZ+ISHhxzVb9KVeakf75tUQe6CXW2gugSCXNw==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.8.tgz",
+      "integrity": "sha512-Ql8elcUdYCha83Ol7NznBsgN5GVZnv3vUd86fEc6waU6oUdY0T1O9NODkEEOS/Uaogr87avDrUC6DSeM4oXjZg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -1122,6 +1124,8 @@
     },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
+      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -1129,7 +1133,7 @@
     },
     "node_modules/@babel/code-frame": {
       "version": "7.28.6",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -1152,6 +1156,7 @@
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3160,6 +3165,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.14.tgz",
       "integrity": "sha512-IN/tlqd7Nl9gl6f0jsWEuOrQDaCI9vHzxv0fisHysfBQzfQIkqlv5A7w4Qge02BUQyczXT9HHPgHtWHCxhjRng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -3215,6 +3221,7 @@
       "integrity": "sha512-7OXPPMoDr6z+5NkoQKu4hOhfjz/YYqM3bNilPqv1WVFWrzSmuNXxvhbX69YMmNmRYascPXiwESqf5jJdjKXEww==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3274,6 +3281,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.14.tgz",
       "integrity": "sha512-Fs+/j+mBSBSXErOQJ/YdUn/HqJGSJ4pGfiJyYOyz04l42uNVnqEakvu1kXLbxMabR6vd6/h9d6Bi4tso9p7o4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3528,6 +3536,7 @@
     "node_modules/@nestjs/typeorm": {
       "version": "11.0.0",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -3589,16 +3598,10 @@
         "npm": ">=5.10.0"
       }
     },
-    "node_modules/@one-ini/wasm": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
-      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3618,6 +3621,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.5.1.tgz",
       "integrity": "sha512-MHbu8XxCHcBn6RwvCt2Vpn1WnLMNECfNKYB14LI5XypcgH4IE0/DiVifVR9tAkwPMyLXN8dOoPJfya3IryLQVw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -3630,6 +3634,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.1.tgz",
       "integrity": "sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -4065,6 +4070,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.1.tgz",
       "integrity": "sha512-BViBCdE/GuXRlp9k7nS1w6wJvY5fnFX5XvuEtWsTAOQFIO89Eru7lGW3WbfbxtCuZ/GbrJfAziXG0w0dpxL7eQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4081,6 +4087,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.1.tgz",
       "integrity": "sha512-iZH3Gw8cxQn0gjpOjJMmKLd9GIaNh/E3v3ST67vyzLSxHBs14HsG4dy7jMYyC5WXGdBVEcM7U/XTF5hCQxjDMw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.1",
         "@opentelemetry/resources": "2.5.1",
@@ -4096,6 +4103,7 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.39.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -5155,6 +5163,7 @@
       "version": "9.5.1",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@inquirer/prompts": "^8.0.0",
         "@stryker-mutator/api": "9.5.1",
@@ -5778,6 +5787,16 @@
       "version": "0.3.0",
       "license": "MIT"
     },
+    "node_modules/@trysound/sax": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -5904,6 +5923,7 @@
       "version": "9.6.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -6060,6 +6080,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.1.tgz",
       "integrity": "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -6144,6 +6165,13 @@
       "version": "1.2.7",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/relateurl": {
+      "version": "0.2.33",
+      "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.33.tgz",
+      "integrity": "sha512-bTQCKsVbIdzLqZhLkF5fcJQreE4y1ro4DIyVrlDNSCJRRwHhB8Z+4zXXa8jN6eDvc2HbRsEYgbvrnGvi54EpSw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
@@ -6254,6 +6282,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -6877,16 +6906,6 @@
         "libqp": "2.1.1"
       }
     },
-    "node_modules/abbrev": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
-      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "license": "MIT",
@@ -6903,6 +6922,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6957,6 +6977,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7317,7 +7338,7 @@
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.11",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -7407,7 +7428,9 @@
       "optional": true
     },
     "node_modules/bowser": {
-      "version": "2.13.1",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
     "node_modules/boxen": {
@@ -7489,7 +7512,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7505,6 +7528,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7628,7 +7652,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7642,9 +7666,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/caniuse-api": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
+      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "browserslist": "^4.0.0",
+        "caniuse-lite": "^1.0.0",
+        "lodash.memoize": "^4.1.2",
+        "lodash.uniq": "^4.5.0"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001761",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7706,22 +7743,26 @@
       }
     },
     "node_modules/cheerio": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-      "integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "htmlparser2": "^8.0.1",
-        "parse5": "^7.0.0",
-        "parse5-htmlparser2-tree-adapter": "^7.0.0"
+        "domutils": "^3.1.0",
+        "encoding-sniffer": "^0.2.0",
+        "htmlparser2": "^9.1.0",
+        "parse5": "^7.1.2",
+        "parse5-htmlparser2-tree-adapter": "^7.0.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^6.19.5",
+        "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">=18.17"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
@@ -7745,10 +7786,31 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cheerio/node_modules/htmlparser2": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -7787,13 +7849,15 @@
     },
     "node_modules/class-transformer": {
       "version": "0.5.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -7949,6 +8013,13 @@
       "version": "1.1.4",
       "license": "MIT"
     },
+    "node_modules/colord": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "license": "MIT",
@@ -7998,17 +8069,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
-      }
-    },
-    "node_modules/config-chain": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
-      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
       }
     },
     "node_modules/consola": {
@@ -8168,6 +8228,19 @@
       "version": "1.0.1",
       "license": "ISC"
     },
+    "node_modules/css-declaration-sorter": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.1.tgz",
+      "integrity": "sha512-gz6x+KkgNCjxq3Var03pRYLhyNfwhkKF1g/yoLgDNtFvVu0/fOLV9C8fFEZRjACp/XQLumjAYo7JVjzH3wLbxA==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^14 || ^16 || >=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.9"
+      }
+    },
     "node_modules/css-select": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -8185,6 +8258,20 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -8197,6 +8284,132 @@
       "funding": {
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cssnano-preset-default": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.10.tgz",
+      "integrity": "sha512-6ZBjW0Lf1K1Z+0OKUAUpEN62tSXmYChXWi2NAA0afxEVsj9a+MbcB1l5qel6BHJHmULai2fCGRthCeKSFbScpA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "browserslist": "^4.27.0",
+        "css-declaration-sorter": "^7.2.0",
+        "cssnano-utils": "^5.0.1",
+        "postcss-calc": "^10.1.1",
+        "postcss-colormin": "^7.0.5",
+        "postcss-convert-values": "^7.0.8",
+        "postcss-discard-comments": "^7.0.5",
+        "postcss-discard-duplicates": "^7.0.2",
+        "postcss-discard-empty": "^7.0.1",
+        "postcss-discard-overridden": "^7.0.1",
+        "postcss-merge-longhand": "^7.0.5",
+        "postcss-merge-rules": "^7.0.7",
+        "postcss-minify-font-values": "^7.0.1",
+        "postcss-minify-gradients": "^7.0.1",
+        "postcss-minify-params": "^7.0.5",
+        "postcss-minify-selectors": "^7.0.5",
+        "postcss-normalize-charset": "^7.0.1",
+        "postcss-normalize-display-values": "^7.0.1",
+        "postcss-normalize-positions": "^7.0.1",
+        "postcss-normalize-repeat-style": "^7.0.1",
+        "postcss-normalize-string": "^7.0.1",
+        "postcss-normalize-timing-functions": "^7.0.1",
+        "postcss-normalize-unicode": "^7.0.5",
+        "postcss-normalize-url": "^7.0.1",
+        "postcss-normalize-whitespace": "^7.0.1",
+        "postcss-ordered-values": "^7.0.2",
+        "postcss-reduce-initial": "^7.0.5",
+        "postcss-reduce-transforms": "^7.0.1",
+        "postcss-svgo": "^7.1.0",
+        "postcss-unique-selectors": "^7.0.4"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/cssnano-preset-lite": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-lite/-/cssnano-preset-lite-4.0.4.tgz",
+      "integrity": "sha512-iV7xT9JEk0OJwRWuSV2Y48IkntNjvoiscoioFDcgmuoIvpZV8gIg1++GBHTj72HgmDCALH8y9ELgt+aFM2Nh9g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cssnano-utils": "^5.0.1",
+        "postcss-discard-comments": "^7.0.4",
+        "postcss-discard-empty": "^7.0.1",
+        "postcss-normalize-whitespace": "^7.0.1"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/cssnano-utils": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.1.tgz",
+      "integrity": "sha512-ZIP71eQgG9JwjVZsTPSqhc6GHgEr53uJ7tK5///VfyWj6Xp2DBmixWHqJgPno+PqATzn48pL42ww9x5SSGmhZg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
+      "license": "CC0-1.0",
+      "optional": true
     },
     "node_modules/dayjs": {
       "version": "1.11.19",
@@ -8413,38 +8626,6 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
-    "node_modules/dot-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
-      "integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/dot-case/node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/dot-case/node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/dotenv": {
       "version": "17.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
@@ -8499,35 +8680,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/editorconfig": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
-      "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@one-ini/wasm": "0.1.1",
-        "commander": "^10.0.0",
-        "minimatch": "9.0.1",
-        "semver": "^7.5.3"
-      },
-      "bin": {
-        "editorconfig": "bin/editorconfig"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/editorconfig/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "license": "MIT"
@@ -8547,7 +8699,7 @@
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -8582,6 +8734,33 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.18.4",
       "dev": true,
@@ -8604,9 +8783,19 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -8705,6 +8894,7 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -8759,6 +8949,7 @@
       "version": "10.1.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9031,6 +9222,7 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9072,6 +9264,7 @@
     "node_modules/express-rate-limit": {
       "version": "8.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "10.0.1"
       },
@@ -9197,10 +9390,22 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
+      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/fast-xml-parser": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
-      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
+      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
       "funding": [
         {
           "type": "github",
@@ -9209,6 +9414,7 @@
       ],
       "license": "MIT",
       "dependencies": {
+        "fast-xml-builder": "^1.0.0",
         "strnum": "^2.1.2"
       },
       "bin": {
@@ -9826,6 +10032,81 @@
         "node": ">=14"
       }
     },
+    "node_modules/htmlnano": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.1.5.tgz",
+      "integrity": "sha512-IXffzXq1beGQN2rsr03aIPK/rVU1jR2uwHymlAIEf97Tl5WdpG50IsQ5nWGvSGQJ+x6U7S6yac9rRiFgAg4/xQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/relateurl": "^0.2.33",
+        "cosmiconfig": "^9.0.0",
+        "posthtml": "^0.16.5"
+      },
+      "peerDependencies": {
+        "cssnano": "^7.0.0",
+        "postcss": "^8.3.11",
+        "purgecss": "^7.0.2",
+        "relateurl": "^0.2.7",
+        "srcset": "5.0.1",
+        "svgo": "^3.0.2",
+        "terser": "^5.10.0",
+        "uncss": "^0.17.3"
+      },
+      "peerDependenciesMeta": {
+        "cssnano": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "purgecss": {
+          "optional": true
+        },
+        "relateurl": {
+          "optional": true
+        },
+        "srcset": {
+          "optional": true
+        },
+        "svgo": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "uncss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/htmlnano/node_modules/cosmiconfig": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "env-paths": "^2.2.1",
+        "import-fresh": "^3.3.0",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.9.5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "8.0.2",
       "funding": [
@@ -9929,7 +10210,7 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -9994,6 +10275,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.3.tgz",
       "integrity": "sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.0",
         "cluster-key-slot": "^1.1.0",
@@ -10029,7 +10311,7 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-binary-path": {
@@ -10150,6 +10432,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/is-json": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
+      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -10335,6 +10624,7 @@
       "version": "30.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -10903,38 +11193,6 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
-    "node_modules/js-beautify": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
-      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "config-chain": "^1.1.13",
-        "editorconfig": "^1.0.4",
-        "glob": "^10.4.2",
-        "js-cookie": "^3.0.5",
-        "nopt": "^7.2.1"
-      },
-      "bin": {
-        "css-beautify": "js/bin/css-beautify.js",
-        "html-beautify": "js/bin/html-beautify.js",
-        "js-beautify": "js/bin/js-beautify.js"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/js-md4": {
       "version": "0.3.2",
       "dev": true,
@@ -10949,7 +11207,7 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -10980,7 +11238,7 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/json-rpc-2.0": {
@@ -11064,33 +11322,47 @@
       "optional": true
     },
     "node_modules/juice": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/juice/-/juice-10.0.1.tgz",
-      "integrity": "sha512-ZhJT1soxJCkOiO55/mz8yeBKTAJhRzX9WBO+16ZTqNTONnnVlUPyVBIzQ7lDRjaBdTbid+bAnyIon/GM3yp4cA==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/juice/-/juice-11.1.1.tgz",
+      "integrity": "sha512-4SBfZqKcc6DrIS+5b/WiGoWaZsdUPBH+e6SbRlNjJpaIRtfoBhYReAtobIEW6mcLeFFDXLBJMuZwkJLkBJjs2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "cheerio": "1.0.0-rc.12",
-        "commander": "^6.1.0",
+        "cheerio": "1.0.0",
+        "commander": "^12.1.0",
+        "entities": "^7.0.0",
         "mensch": "^0.3.4",
         "slick": "^1.12.2",
-        "web-resource-inliner": "^6.0.1"
+        "web-resource-inliner": "^8.0.0"
       },
       "bin": {
         "juice": "bin/juice"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/juice/node_modules/commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">= 6"
+        "node": ">=18"
+      }
+    },
+    "node_modules/juice/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/jwa": {
@@ -11189,9 +11461,22 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/linkify-it": {
@@ -11321,12 +11606,19 @@
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -11428,6 +11720,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "license": "CC0-1.0",
+      "optional": true
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -11549,9 +11848,9 @@
       "license": "ISC"
     },
     "node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -11580,104 +11879,90 @@
       }
     },
     "node_modules/mjml": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml/-/mjml-4.18.0.tgz",
-      "integrity": "sha512-rQM4aqFRrNvV1k733e8hJSopBjZvoSdBpRYzNTMAN+As0jqJsO5eN0wTT2IFtfe4PREzzu5b06RkPiUQdd0IIg==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml/-/mjml-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-ZZS2NaiK24+Wx1aIB5b1t7oKtYuTjsgqCxDaVPsWWHBIRKpTaLVxbcJQXjDyKOGz7PTWUgDY0OEj1O1wtL/jYQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "mjml-cli": "4.18.0",
-        "mjml-core": "4.18.0",
-        "mjml-migrate": "4.18.0",
-        "mjml-preset-core": "4.18.0",
-        "mjml-validator": "4.18.0"
+        "mjml-cli": "5.0.0-alpha.11",
+        "mjml-core": "5.0.0-alpha.11",
+        "mjml-preset-core": "5.0.0-alpha.11",
+        "mjml-validator": "5.0.0-alpha.11"
       },
       "bin": {
         "mjml": "bin/mjml"
       }
     },
     "node_modules/mjml-accordion": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-accordion/-/mjml-accordion-4.18.0.tgz",
-      "integrity": "sha512-9PUmy2JxIOGgAaVHvgVYX21nVAo3o/+wJckTTF/YTLGAqB+nm+44buxRzaXxVk7qXRwbCNfE8c8mlGVNh7vB1g==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-accordion/-/mjml-accordion-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-ZWzJiClvYvIwR00GaylcMM9GvMaR8qa/tkbCGgwDQBni8aO5H1bl+MvtbC4g7xuWQAlPXJnC8ExZVuze28n29A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-body": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-body/-/mjml-body-4.18.0.tgz",
-      "integrity": "sha512-34AwX70/7NkRIajPsa5j6NySRiNrlLatTKhiLwTVFiVtrEFlfCcbeMNmdVixI3Ldvs8209ZC6euaAnXDRyR1zw==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-body/-/mjml-body-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-c2G4HOg1wFmTm1oktL9ny2oWaLV9PtsqeJt9SFw7YSqkU2lRKGvuvgPfQFEOB4F4fNw5ITQqE0AMQlrIclUL4w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-button": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-button/-/mjml-button-4.18.0.tgz",
-      "integrity": "sha512-ZsWMI0j7EcFCMqbqdVwMWhmsVc03FhmypWXokKopGhwySn4IAB4AOURonRmFrO7k6sDeQ+iJ9QtTu7jA+S8wmg==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-button/-/mjml-button-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-caaT8Slt4V2Z8e7WaN9a50Xy7ewhx0IBSgFkFw1N/AzrOSgg2unKxSeAEuL7cigK6OtExSMxz0xsgY7+H3lwHA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-carousel": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-carousel/-/mjml-carousel-4.18.0.tgz",
-      "integrity": "sha512-wY4g1CHCOoVSZuar7CLFon/qkPbICu71IT+6pa4BDwkAiaAMAemZPyy+a+iIUgdc8kHgSuHGsGf6PQzBSMWRZA==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-carousel/-/mjml-carousel-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-PY/AJfATRgVJbS+buOEFH25tJ18ooXfHI/kDmqEclU8TlYLIqLXvE/BJjkblXtomtNzBhVWWGeu7d7AXbqNVnw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-cli": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-cli/-/mjml-cli-4.18.0.tgz",
-      "integrity": "sha512-N6CnA4o/q/VRnGPxTzvVnjAEcF7WUVVQGYfS9SPAp0qwyf7RysMmewdS9yN8GwXwZV6L2sKdn+3ANNi2FNsJ7w==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-cli/-/mjml-cli-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-18juF8daEX222zSvsYmHoedKdLlKRMIdVRBGwJ/vRbChkP5aHywkonzG+1cfmZWnYTSrZh/liTjXFgrYdNBkfQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "chokidar": "^3.0.0",
-        "glob": "^10.3.10",
-        "html-minifier": "^4.0.0",
-        "js-beautify": "^1.6.14",
+        "glob": "^10.5.0",
         "lodash": "^4.17.21",
         "minimatch": "^9.0.3",
-        "mjml-core": "4.18.0",
-        "mjml-migrate": "4.18.0",
-        "mjml-parser-xml": "4.18.0",
-        "mjml-validator": "4.18.0",
+        "mjml-core": "5.0.0-alpha.11",
+        "mjml-parser-xml": "5.0.0-alpha.11",
+        "mjml-preset-core": "5.0.0-alpha.11",
+        "mjml-validator": "5.0.0-alpha.11",
         "yargs": "^17.7.2"
       },
       "bin": {
         "mjml-cli": "bin/mjml"
-      }
-    },
-    "node_modules/mjml-cli/node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/mjml-cli/node_modules/chokidar": {
@@ -11705,29 +11990,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/mjml-cli/node_modules/clean-css": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
-      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 10.0"
-      }
-    },
-    "node_modules/mjml-cli/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/mjml-cli/node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -11739,40 +12001,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/mjml-cli/node_modules/html-minifier": {
-      "name": "html-minifier-terser",
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
-      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "clean-css": "~5.3.2",
-        "commander": "^10.0.0",
-        "entities": "^4.4.0",
-        "param-case": "^3.0.4",
-        "relateurl": "^0.2.7",
-        "terser": "^5.15.1"
-      },
-      "bin": {
-        "html-minifier-terser": "cli.js"
-      },
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/mjml-cli/node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
       }
     },
     "node_modules/mjml-cli/node_modules/picomatch": {
@@ -11801,303 +12029,199 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/mjml-cli/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/mjml-column": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-column/-/mjml-column-4.18.0.tgz",
-      "integrity": "sha512-0QZ1whxbHUmJaRT8tW+wmr3fWZ/kpsHKAd24c7Z/N1Otm/U2G0T/FFEFJ6cB25X6ZN0K40QZ8L9gdLfiSVuRbA==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-column/-/mjml-column-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-h6tvdx9tPjADoRQ3hV5InTK7j0w93fIenWvLaFmGx6F0b+BF6Uie+3L5hgNLmsuHLWHEJuaKsiviklHNP87Lew==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-core": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-core/-/mjml-core-4.18.0.tgz",
-      "integrity": "sha512-yey72LszXvIo5p0R6DB+YU8er/nP2wPsqpLKQCB0H8vG0WRT1sbSUvnCUOkKGn7subuyWDTdzHKbQO3XYIOmvg==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-core/-/mjml-core-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-7j+MZzO3gb7jezfLUy8eFmMez9ctTuLoFFbFQuCfab/7UMsEbeKxodPZ6tSuQNKUfNQzJnpZFRhPxVDrmTRUoA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "cheerio": "1.0.0-rc.12",
+        "cheerio": "1.0.0",
+        "cssnano": "^7.0.6",
+        "cssnano-preset-lite": "^4.0.4",
         "detect-node": "^2.0.4",
-        "html-minifier": "^4.0.0",
-        "js-beautify": "^1.6.14",
-        "juice": "^10.0.0",
+        "htmlnano": "^2.1.1",
+        "juice": "^11.0.0",
         "lodash": "^4.17.21",
-        "mjml-migrate": "4.18.0",
-        "mjml-parser-xml": "4.18.0",
-        "mjml-validator": "4.18.0"
-      }
-    },
-    "node_modules/mjml-core/node_modules/camel-case": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
-      "integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "pascal-case": "^3.1.2",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/mjml-core/node_modules/clean-css": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
-      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 10.0"
-      }
-    },
-    "node_modules/mjml-core/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/mjml-core/node_modules/html-minifier": {
-      "name": "html-minifier-terser",
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-7.2.0.tgz",
-      "integrity": "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "camel-case": "^4.1.2",
-        "clean-css": "~5.3.2",
-        "commander": "^10.0.0",
-        "entities": "^4.4.0",
-        "param-case": "^3.0.4",
-        "relateurl": "^0.2.7",
-        "terser": "^5.15.1"
-      },
-      "bin": {
-        "html-minifier-terser": "cli.js"
-      },
-      "engines": {
-        "node": "^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/mjml-core/node_modules/param-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
-      "integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "dot-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/mjml-core/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
+        "mjml-parser-xml": "5.0.0-alpha.11",
+        "mjml-validator": "5.0.0-alpha.11",
+        "postcss": "^8.5.3",
+        "prettier": "^3.5.1"
       }
     },
     "node_modules/mjml-divider": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-divider/-/mjml-divider-4.18.0.tgz",
-      "integrity": "sha512-FmGUVJqi4RYroh7y85vDx0aUKZgECkxHtMQ4pkLGQbZ2g93/Qt0Ek88DVCNJ5XwUAQQkE/TvrGMLHp3CIqpQ9Q==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-divider/-/mjml-divider-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-EvVhI8TnjFyr0RW7U50HZMm52fnbMYS7KO0SsQtdJ64srCthBPXG9el54Kjnf4qrHHoab+SYuHdIJg8oF9PPyg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-group": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-group/-/mjml-group-4.18.0.tgz",
-      "integrity": "sha512-28ABkXsKljBqj7XCC8GkQ94xz8HEU2XTyD+9LTlkDafzGp/MGJb8DcLh/7IkxCwqkQWyeMiDNLf1djsQ909Vxw==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-group/-/mjml-group-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-PtqdxB28GUNlBD9NxfffHgx26TK4sRhBs7UJthZOAxz8JkaFBKgdax+6LJBlrK7ZoY4YtYdyY7yGnGA5g8DJ5g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-head": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-head/-/mjml-head-4.18.0.tgz",
-      "integrity": "sha512-DS0adpIAsVMDIk2DOsHzjg+RNjQU0fF8jiVP9BmdRHVGrLPmpL9wIHZk2KvsKvZe7VaXXBijFt3DZ5/CQ/+D7Q==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-head/-/mjml-head-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-Y4R8I4zLv3fbJR4sKR7iq9i1OwxhEmbuXWpWoBBXK9XftjABEEjYtuQNC66Rw47Jx2EfWKmG8E6AFMjm8DuLGA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-head-attributes": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-attributes/-/mjml-head-attributes-4.18.0.tgz",
-      "integrity": "sha512-nLzix1wrMnojE0RPGhk4iKqSRwHKjie2EPzgKT7CDzfqN+Ref03E5Q19x3cQTLgxvq3C3CnvCQBfnhoS3Eakug==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-head-attributes/-/mjml-head-attributes-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-QXVN9/K8y0c2v2oeP+iBmPeHEwkRMszX7rl6EmSHFHcoXPg0Ah50rlTydpocEjawuhG+2vKP7A7if0MVkVf8KQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-head-breakpoint": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-breakpoint/-/mjml-head-breakpoint-4.18.0.tgz",
-      "integrity": "sha512-k6rwff+7i+vTQYJ/CjBfE20qNqPaW60IRH2x2oEPuCzmwDmoVWOcplJIuotSqIAdfwF9hLkICknisp1BpczVlQ==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-head-breakpoint/-/mjml-head-breakpoint-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-25yyR6QMKcFmPvFbi/Qa/23AJk8gh7xEx+CHyPecIyMduCys0QRgI27XBTHoJq36ea10p17MD5SYmVboETjSVQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-head-font": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-font/-/mjml-head-font-4.18.0.tgz",
-      "integrity": "sha512-ao8HB5nf+Dmxw4GO6lMMOlnj1lNZONai0GC9RobrZgPlghZw6hpURWGpkON7pQcy6XnOHwYwkV7Go/npzA2i7w==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-head-font/-/mjml-head-font-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-/fUORt3H7S9Lf2fMhOjKdChK7CVZSwTMna4tfzC0HnWIdWRB37++EBqxs01PmhgdkHkB/yj290cIpwb3q3T4pQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-head-html-attributes": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-html-attributes/-/mjml-head-html-attributes-4.18.0.tgz",
-      "integrity": "sha512-xaQE1rthe0RrNotwEr71X1tE+QQ489Yc0ynMm3oNMrohDI/TaCeazx8GAHPMM7VLduDA8D4A5wkZ6PuEvlJu4w==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-head-html-attributes/-/mjml-head-html-attributes-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-bQxWssXxxJ83gJEeJoa8SzqedMrIVAHLRGKqS7VeGPEGwjDsciP12l7Jinlb7AMHzR7VV0TOxd+FK7Ys43hbMg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-head-preview": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-preview/-/mjml-head-preview-4.18.0.tgz",
-      "integrity": "sha512-2JvYqhbLyU/+Te6/1AXxzTNoHYCDYhXOVZP7wMvU4t7K34pXqyRUNO405atyHUY1MRafrl6RJ8cIx0x5vUX7PA==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-head-preview/-/mjml-head-preview-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-eSQt0ErwMrXY2Bh1NqL1dA/vjOLzy8JqbaAjjvjvQO9NCbBAXVSGCRWPZbp3wRYvHhPhWZ+GISSBQr18w2itTw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-head-style": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-style/-/mjml-head-style-4.18.0.tgz",
-      "integrity": "sha512-nEwDHkAqY3Fm7QWeAZc/a7MakZpXh6THfrE8/AWrfpgzTHrD/wihNUc09ztNpr6z/K1+JWgQfSF2BRc+X3P46g==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-head-style/-/mjml-head-style-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-niZS4jR2QTYpQnRM937utgkQNfrIZZkbvLw9KQRxdLGQdpLC5r0oGpbTDLilW9UiTqkYoXdYwSBAEs5lqgY0Mg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-head-title": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-head-title/-/mjml-head-title-4.18.0.tgz",
-      "integrity": "sha512-0Hm8o50rPMUQLSCOOa4D4pz9NajmCDccLvBYE4fwKdeUXjSJ6bwAYeMpveel8oNZMDUVJ4Hx+PskisEGHMHM2w==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-head-title/-/mjml-head-title-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-EuzUnNXj1uIJWu0hrkbJY9akFtWxDUkJtRmUOtO6VDYa5mj/u3Wwb9Ed/RQOZOyvA7ft0n1fkDuxCmqEJynCfQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-hero": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-hero/-/mjml-hero-4.18.0.tgz",
-      "integrity": "sha512-rujm0ROM4QGWw77vnl3NaVaCKXrT4xTSHeAnkHKiY5AuRf6HPTgEtutq5pdel/y6Q9GrmxvN3HRESum7tpJCJw==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-hero/-/mjml-hero-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-BMuWuiI+eSWoizgL4aw/v620FFPWrjiM6jLfGKmTIkma/gnmRf0irshjW+BD7W8yq71ksHZQJEny/eZUUuy7DQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-image": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-image/-/mjml-image-4.18.0.tgz",
-      "integrity": "sha512-e09NkoYwvzMcTv7V6H5doWD6Te2E1y2EvOLQJoXKVdQpDwyBWGdfnZke0scJGdA58HLAB+0mLYogpLwmfLaP5Q==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-image/-/mjml-image-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-FRvjSNU9vMCNSw1pEalVbO7KnWbHzwflhns/hQdm/o4stkV7fEKrPW0Yh31hkwOYEyZzMXBoQyEHH0C5U4asHQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
-      }
-    },
-    "node_modules/mjml-migrate": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-migrate/-/mjml-migrate-4.18.0.tgz",
-      "integrity": "sha512-qfNCgW9zhJIsbPyXFA5RT/WY4mlje3N0WhHHOsHc0nY89Q01DenyslUy9nLLGXwi4K5FHS58oCjwWbMhwDcj1w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@babel/runtime": "^7.28.4",
-        "js-beautify": "^1.6.14",
-        "lodash": "^4.17.21",
-        "mjml-core": "4.18.0",
-        "mjml-parser-xml": "4.18.0",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "migrate": "lib/cli.js"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-navbar": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-navbar/-/mjml-navbar-4.18.0.tgz",
-      "integrity": "sha512-uho/MS2tfNAe+V9u2X7NoCco34MDbdp30ETA8009Qo1VCP/D8lZ+s69WGRPu6hvN/Y2pzBgZly++CMg3qFZqBQ==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-navbar/-/mjml-navbar-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-CWx35J+CnrTHax9kvIZxlHdFefhTiNKb1Sd2D4BaYdVRdtRzIlPVNoBvoxcSiATZbD+XNPpYgAO3+i7XbAVPMQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-parser-xml": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-parser-xml/-/mjml-parser-xml-4.18.0.tgz",
-      "integrity": "sha512-sHSsZg4afY1heThuJzxa1Kvfh/QzB7/9P5fFUHeVnnxb07ZTXnhXWA6YbobdND5/l9+5yjN5/UgqDZm3tIT4Uw==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-parser-xml/-/mjml-parser-xml-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-7jk6IcfwSWyUAa9wsK9GT9yA6Kit3l3h+STWFtrRMRdIEUmIiHN7UPDoUSNuSj3Zwg9XNHmHHz0lQtptBSm+Ag==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12128,116 +12252,116 @@
       }
     },
     "node_modules/mjml-preset-core": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-preset-core/-/mjml-preset-core-4.18.0.tgz",
-      "integrity": "sha512-x3l8vMVtsaqM/jauMeZIN7HFD2t5A28J4U0o4849yIlRxiWguLFV5l3BL8Byol+YLkoLuT9PjaZs9RYv+FGfeg==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-preset-core/-/mjml-preset-core-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-ZdMZBFvx+DpUGUuQpYTkXpqoIZjEH824t3Kpj7lXbA+witVL8DCOJCKvCQssxcAP39MmfP3FJVm/SHiVVLPgTw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "mjml-accordion": "4.18.0",
-        "mjml-body": "4.18.0",
-        "mjml-button": "4.18.0",
-        "mjml-carousel": "4.18.0",
-        "mjml-column": "4.18.0",
-        "mjml-divider": "4.18.0",
-        "mjml-group": "4.18.0",
-        "mjml-head": "4.18.0",
-        "mjml-head-attributes": "4.18.0",
-        "mjml-head-breakpoint": "4.18.0",
-        "mjml-head-font": "4.18.0",
-        "mjml-head-html-attributes": "4.18.0",
-        "mjml-head-preview": "4.18.0",
-        "mjml-head-style": "4.18.0",
-        "mjml-head-title": "4.18.0",
-        "mjml-hero": "4.18.0",
-        "mjml-image": "4.18.0",
-        "mjml-navbar": "4.18.0",
-        "mjml-raw": "4.18.0",
-        "mjml-section": "4.18.0",
-        "mjml-social": "4.18.0",
-        "mjml-spacer": "4.18.0",
-        "mjml-table": "4.18.0",
-        "mjml-text": "4.18.0",
-        "mjml-wrapper": "4.18.0"
+        "mjml-accordion": "5.0.0-alpha.11",
+        "mjml-body": "5.0.0-alpha.11",
+        "mjml-button": "5.0.0-alpha.11",
+        "mjml-carousel": "5.0.0-alpha.11",
+        "mjml-column": "5.0.0-alpha.11",
+        "mjml-divider": "5.0.0-alpha.11",
+        "mjml-group": "5.0.0-alpha.11",
+        "mjml-head": "5.0.0-alpha.11",
+        "mjml-head-attributes": "5.0.0-alpha.11",
+        "mjml-head-breakpoint": "5.0.0-alpha.11",
+        "mjml-head-font": "5.0.0-alpha.11",
+        "mjml-head-html-attributes": "5.0.0-alpha.11",
+        "mjml-head-preview": "5.0.0-alpha.11",
+        "mjml-head-style": "5.0.0-alpha.11",
+        "mjml-head-title": "5.0.0-alpha.11",
+        "mjml-hero": "5.0.0-alpha.11",
+        "mjml-image": "5.0.0-alpha.11",
+        "mjml-navbar": "5.0.0-alpha.11",
+        "mjml-raw": "5.0.0-alpha.11",
+        "mjml-section": "5.0.0-alpha.11",
+        "mjml-social": "5.0.0-alpha.11",
+        "mjml-spacer": "5.0.0-alpha.11",
+        "mjml-table": "5.0.0-alpha.11",
+        "mjml-text": "5.0.0-alpha.11",
+        "mjml-wrapper": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-raw": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-raw/-/mjml-raw-4.18.0.tgz",
-      "integrity": "sha512-F/kViAwXm3ccPP52kw++/mHQbcYbYYxC8JH15TZxH8GLVZkX5CGKgcBrHhDK7WoIlfEIsVRZ6IZdlHjH8vgyxw==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-raw/-/mjml-raw-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-aF6sbTW/kDYErHSAMOi9+8mGIsw721ebo9HEWkAkkp4YOiaLUiOmNUXy10bObOW7DKfUnI35afd5HxpNnkITWw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-section": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-section/-/mjml-section-4.18.0.tgz",
-      "integrity": "sha512-bB8My9zvIEkTOxej+TrjEeaeRT0lsypGeRADtdrRZXeqUClkkuCnCXlsNKSLGT8ZRqjUqWRc5z8ubDOvGk2+Gg==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-section/-/mjml-section-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-hzAbxdBWVB1GJ5IueKURzGQ5t9QEHaTTBsKtlvbAheFIx2VFCAPCs4oOZm4ZAj/0dIRyI3Cr3FNlsxkrF3x5Og==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-social": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-social/-/mjml-social-4.18.0.tgz",
-      "integrity": "sha512-iAQc9g59L6L3VHDd55BxeIvk/zHkxflxmvuyYyOOvpmmKAvUBC//ULfpxiiM4yupofsThqFfrO+wc8d4kTRkbQ==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-social/-/mjml-social-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-QjGb0RV2wO+lPAMNUFN8ziQcfo6RI0qgolFSBylWNK7J33kXg9kT7fMr4EPEPTa0XH24A9J0x2RAhnlSAWFM2Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-spacer": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-spacer/-/mjml-spacer-4.18.0.tgz",
-      "integrity": "sha512-FK/0f5IBiONgaRpwNBs7G8EbLdAbmYqcIfHR8O8tP4LipAChLQKHO9vX3vrRMGLBZZNTESLObcFSVWmA40Mfpw==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-spacer/-/mjml-spacer-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-3HdF3QTSASf3FYU4AM1HPcQa2yDlHF6UpNjjitTM1v5s1TkgylshbR9QkcNQAtHWN1VmaeNwVSXuK9GGvAu3gQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-table": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-table/-/mjml-table-4.18.0.tgz",
-      "integrity": "sha512-vJysCPUL3CHcsQDAFpW+skzBtY0RYsmMBYswI4WX0B05GLKlOjXqpYOwcmAupWeGoBVL5r/t28ynu2PqnOlN3w==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-table/-/mjml-table-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-C9aEyQhSdQcDjUbKGs5sYwSPfN68/W2prycfMt9y0hx0d6aJupHJSU+1u8Dfum+X/zdT2UjdHtJNYJK8VwD/0Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-text": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-text/-/mjml-text-4.18.0.tgz",
-      "integrity": "sha512-hBLmF3JgveUKktKQFWHqHAr7qr92j1CxAvq7mtpDUgiWgyPFzqRX8mUsFYgZ7DmRxG4UE+Kzpt8/YFd9+E98lw==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-text/-/mjml-text-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-+AiY3LzWJuJS6P3CuDPTOCT2raA/6V3ko512VxWkbMeAyc1WXtPgFG6CcLjULE3o69e699njeVpE4x+yuVxo2g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11"
       }
     },
     "node_modules/mjml-validator": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-validator/-/mjml-validator-4.18.0.tgz",
-      "integrity": "sha512-JmpWAsNTUlAxJOz2zHYfF8Vod8OzM3Qp5JXtrVw5tivZQzq88ZfqVGuqsas51z0pp1/ilfD4lC17YGfGwKGyhA==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-validator/-/mjml-validator-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-RX6iwFTtSzAUO4jLLntyA3AGz2L5jbENlYPijqHhyQ6pC0U4ysvXoz8w67SPdeHiEgCtmsyGd5kHniJ1OMJeDw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12245,16 +12369,16 @@
       }
     },
     "node_modules/mjml-wrapper": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/mjml-wrapper/-/mjml-wrapper-4.18.0.tgz",
-      "integrity": "sha512-TZeOvLjIhXEK60rjWNiYhEYNlv5GKYahE+96ifcT5OGkWkRA0DsQDfp+6VI32OS5VxsfKq2h/UdERPlQijjpAQ==",
+      "version": "5.0.0-alpha.11",
+      "resolved": "https://registry.npmjs.org/mjml-wrapper/-/mjml-wrapper-5.0.0-alpha.11.tgz",
+      "integrity": "sha512-p0XA5RX7JGoT6c5kcRtKELI9GEn6MIAD2BMJKd4JzRWdCPPoL69D7BUV88kyjmT6eoLELCTYoUsOsVXFE4EGXw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "4.18.0",
-        "mjml-section": "4.18.0"
+        "mjml-core": "5.0.0-alpha.11",
+        "mjml-section": "5.0.0-alpha.11"
       }
     },
     "node_modules/mkdirp": {
@@ -12328,6 +12452,25 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
       "dev": true,
@@ -12399,27 +12542,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-gyp-build": {
       "version": "4.8.4",
       "license": "MIT",
@@ -12436,30 +12558,15 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/nodemailer": {
       "version": "8.0.1",
       "license": "MIT-0",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/nopt": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
-      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "abbrev": "^2.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/normalize-path": {
@@ -12695,7 +12802,7 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -12706,7 +12813,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -12759,6 +12866,19 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parse5/node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -12790,41 +12910,10 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/pascal-case": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
-      "integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "no-case": "^3.0.4",
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/pascal-case/node_modules/lower-case": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
-      "integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/pascal-case/node_modules/no-case": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
-      "integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "lower-case": "^2.0.2",
-        "tslib": "^2.0.3"
-      }
-    },
     "node_modules/passport": {
       "version": "0.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -12937,6 +13026,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.19.0.tgz",
       "integrity": "sha512-QIcLGi508BAHkQ3pJNptsFz5WQMlpGbuBGBaIaXsWK8mel2kQ/rThYI+DbgjUvZrIr7MiuEuc9LcChJoEZK1xQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.12.0",
@@ -13108,6 +13198,522 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postcss-calc": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
+      "integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12 || ^20.9 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.38"
+      }
+    },
+    "node_modules/postcss-colormin": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.5.tgz",
+      "integrity": "sha512-ekIBP/nwzRWhEMmIxHHbXHcMdzd1HIUzBECaj5KEdLz9DVP2HzT065sEhvOx1dkLjYW7jyD0CngThx6bpFi2fA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "browserslist": "^4.27.0",
+        "caniuse-api": "^3.0.0",
+        "colord": "^2.9.3",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-convert-values": {
+      "version": "7.0.8",
+      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.8.tgz",
+      "integrity": "sha512-+XNKuPfkHTCEo499VzLMYn94TiL3r9YqRE3Ty+jP7UX4qjewUONey1t7CG21lrlTLN07GtGM8MqFVp86D4uKJg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "browserslist": "^4.27.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-discard-comments": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.5.tgz",
+      "integrity": "sha512-IR2Eja8WfYgN5n32vEGSctVQ1+JARfu4UH8M7bgGh1bC+xI/obsPJXaBpQF7MAByvgwZinhpHpdrmXtvVVlKcQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "postcss-selector-parser": "^7.1.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-discard-duplicates": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.2.tgz",
+      "integrity": "sha512-eTonaQvPZ/3i1ASDHOKkYwAybiM45zFIc7KXils4mQmHLqIswXD9XNOKEVxtTFnsmwYzF66u4LMgSr0abDlh5w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-discard-empty": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.1.tgz",
+      "integrity": "sha512-cFrJKZvcg/uxB6Ijr4l6qmn3pXQBna9zyrPC+sK0zjbkDUZew+6xDltSF7OeB7rAtzaaMVYSdbod+sZOCWnMOg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-discard-overridden": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.1.tgz",
+      "integrity": "sha512-7c3MMjjSZ/qYrx3uc1940GSOzN1Iqjtlqe8uoSg+qdVPYyRb0TILSqqmtlSFuE4mTDECwsm397Ya7iXGzfF7lg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-merge-longhand": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.5.tgz",
+      "integrity": "sha512-Kpu5v4Ys6QI59FxmxtNB/iHUVDn9Y9sYw66D6+SZoIk4QTz1prC4aYkhIESu+ieG1iylod1f8MILMs1Em3mmIw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0",
+        "stylehacks": "^7.0.5"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-merge-rules": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.7.tgz",
+      "integrity": "sha512-njWJrd/Ms6XViwowaaCc+/vqhPG3SmXn725AGrnl+BgTuRPEacjiLEaGq16J6XirMJbtKkTwnt67SS+e2WGoew==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "browserslist": "^4.27.0",
+        "caniuse-api": "^3.0.0",
+        "cssnano-utils": "^5.0.1",
+        "postcss-selector-parser": "^7.1.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-minify-font-values": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.1.tgz",
+      "integrity": "sha512-2m1uiuJeTplll+tq4ENOQSzB8LRnSUChBv7oSyFLsJRtUgAAJGP6LLz0/8lkinTgxrmJSPOEhgY1bMXOQ4ZXhQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-minify-gradients": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.1.tgz",
+      "integrity": "sha512-X9JjaysZJwlqNkJbUDgOclyG3jZEpAMOfof6PUZjPnPrePnPG62pS17CjdM32uT1Uq1jFvNSff9l7kNbmMSL2A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "colord": "^2.9.3",
+        "cssnano-utils": "^5.0.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-minify-params": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.5.tgz",
+      "integrity": "sha512-FGK9ky02h6Ighn3UihsyeAH5XmLEE2MSGH5Tc4tXMFtEDx7B+zTG6hD/+/cT+fbF7PbYojsmmWjyTwFwW1JKQQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "browserslist": "^4.27.0",
+        "cssnano-utils": "^5.0.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-minify-selectors": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.5.tgz",
+      "integrity": "sha512-x2/IvofHcdIrAm9Q+p06ZD1h6FPcQ32WtCRVodJLDR+WMn8EVHI1kvLxZuGKz/9EY5nAmI6lIQIrpo4tBy5+ug==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "postcss-selector-parser": "^7.1.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-normalize-charset": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.1.tgz",
+      "integrity": "sha512-sn413ofhSQHlZFae//m9FTOfkmiZ+YQXsbosqOWRiVQncU2BA3daX3n0VF3cG6rGLSFVc5Di/yns0dFfh8NFgQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-normalize-display-values": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.1.tgz",
+      "integrity": "sha512-E5nnB26XjSYz/mGITm6JgiDpAbVuAkzXwLzRZtts19jHDUBFxZ0BkXAehy0uimrOjYJbocby4FVswA/5noOxrQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-normalize-positions": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.1.tgz",
+      "integrity": "sha512-pB/SzrIP2l50ZIYu+yQZyMNmnAcwyYb9R1fVWPRxm4zcUFCY2ign7rcntGFuMXDdd9L2pPNUgoODDk91PzRZuQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-normalize-repeat-style": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.1.tgz",
+      "integrity": "sha512-NsSQJ8zj8TIDiF0ig44Byo3Jk9e4gNt9x2VIlJudnQQ5DhWAHJPF4Tr1ITwyHio2BUi/I6Iv0HRO7beHYOloYQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-normalize-string": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.1.tgz",
+      "integrity": "sha512-QByrI7hAhsoze992kpbMlJSbZ8FuCEc1OT9EFbZ6HldXNpsdpZr+YXC5di3UEv0+jeZlHbZcoCADgb7a+lPmmQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-normalize-timing-functions": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.1.tgz",
+      "integrity": "sha512-bHifyuuSNdKKsnNJ0s8fmfLMlvsQwYVxIoUBnowIVl2ZAdrkYQNGVB4RxjfpvkMjipqvbz0u7feBZybkl/6NJg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-normalize-unicode": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.5.tgz",
+      "integrity": "sha512-X6BBwiRxVaFHrb2WyBMddIeB5HBjJcAaUHyhLrM2FsxSq5TFqcHSsK7Zu1otag+o0ZphQGJewGH1tAyrD0zX1Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "browserslist": "^4.27.0",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-normalize-url": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.1.tgz",
+      "integrity": "sha512-sUcD2cWtyK1AOL/82Fwy1aIVm/wwj5SdZkgZ3QiUzSzQQofrbq15jWJ3BA7Z+yVRwamCjJgZJN0I9IS7c6tgeQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-normalize-whitespace": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.1.tgz",
+      "integrity": "sha512-vsbgFHMFQrJBJKrUFJNZ2pgBeBkC2IvvoHjz1to0/0Xk7sII24T0qFOiJzG6Fu3zJoq/0yI4rKWi7WhApW+EFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-ordered-values": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.2.tgz",
+      "integrity": "sha512-AMJjt1ECBffF7CEON/Y0rekRLS6KsePU6PRP08UqYW4UGFRnTXNrByUzYK1h8AC7UWTZdQ9O3Oq9kFIhm0SFEw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cssnano-utils": "^5.0.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-reduce-initial": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.5.tgz",
+      "integrity": "sha512-RHagHLidG8hTZcnr4FpyMB2jtgd/OcyAazjMhoy5qmWJOx1uxKh4ntk0Pb46ajKM0rkf32lRH4C8c9qQiPR6IA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "browserslist": "^4.27.0",
+        "caniuse-api": "^3.0.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-reduce-transforms": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.1.tgz",
+      "integrity": "sha512-MhyEbfrm+Mlp/36hvZ9mT9DaO7dbncU0CvWI8V93LRkY6IYlu38OPg3FObnuKTUxJ4qA8HpurdQOo5CyqqO76g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-svgo": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.1.0.tgz",
+      "integrity": "sha512-KnAlfmhtoLz6IuU3Sij2ycusNs4jPW+QoFE5kuuUOK8awR6tMxZQrs5Ey3BUz7nFCzT3eqyFgqkyrHiaU2xx3w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "postcss-value-parser": "^4.2.0",
+        "svgo": "^4.0.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >= 18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-svgo/node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/postcss-svgo/node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/postcss-svgo/node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "license": "CC0-1.0",
+      "optional": true
+    },
+    "node_modules/postcss-svgo/node_modules/svgo": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.0.tgz",
+      "integrity": "sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "commander": "^11.1.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^3.0.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.1.1",
+        "sax": "^1.4.1"
+      },
+      "bin": {
+        "svgo": "bin/svgo.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/postcss-unique-selectors": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.4.tgz",
+      "integrity": "sha512-pmlZjsmEAG7cHd7uK3ZiNSW6otSZ13RHuZ/4cDN/bVglS5EpF2r2oxY99SuOHa8m7AWoBCelTS3JPpzsIs8skQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "postcss-selector-parser": "^7.1.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/postgres-array": {
       "version": "2.0.0",
       "license": "MIT",
@@ -13139,6 +13745,135 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/posthtml": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.7.tgz",
+      "integrity": "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "posthtml-parser": "^0.11.0",
+        "posthtml-render": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/posthtml-parser": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+      "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "htmlparser2": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/posthtml-parser/node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/posthtml-parser/node_modules/dom-serializer/node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/posthtml-parser/node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/posthtml-parser/node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/posthtml-parser/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/posthtml-parser/node_modules/htmlparser2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
+    },
+    "node_modules/posthtml-render": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-json": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "dev": true,
@@ -13149,8 +13884,9 @@
     },
     "node_modules/prettier": {
       "version": "3.8.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13290,13 +14026,6 @@
       "dependencies": {
         "asap": "~2.0.3"
       }
-    },
-    "node_modules/proto-list": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
-      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -13629,17 +14358,8 @@
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "license": "Apache-2.0"
-    },
-    "node_modules/relateurl": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
-      "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -13709,7 +14429,7 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -13943,6 +14663,7 @@
     "node_modules/rxjs": {
       "version": "7.8.2",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -13968,6 +14689,16 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
@@ -14218,6 +14949,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "devOptional": true,
@@ -14401,6 +15142,23 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/stylehacks": {
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.7.tgz",
+      "integrity": "sha512-bJkD0JkEtbRrMFtwgpJyBbFIwfDDONQ1Ov3sDLZQP8HuJ73kBOyx66H4bOcAbVWmnfLdvQ0AJwXxOMkpujcO6g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "browserslist": "^4.27.0",
+        "postcss-selector-parser": "^7.1.0"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "license": "MIT",
@@ -14453,6 +15211,42 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svgo": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
+      "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@trysound/sax": "0.2.0",
+        "commander": "^7.2.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^2.3.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/swagger-ui-dist": {
@@ -14520,6 +15314,7 @@
       "version": "5.44.1",
       "devOptional": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -14744,13 +15539,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "dev": true,
@@ -14857,6 +15645,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15052,6 +15841,7 @@
     "node_modules/typeorm": {
       "version": "0.3.28",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -15196,6 +15986,7 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15213,6 +16004,7 @@
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
+      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -15246,6 +16038,16 @@
       "version": "1.13.7",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
+      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.17"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
@@ -15314,7 +16116,7 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -15465,138 +16267,47 @@
       "license": "Apache-2.0"
     },
     "node_modules/web-resource-inliner": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/web-resource-inliner/-/web-resource-inliner-6.0.1.tgz",
-      "integrity": "sha512-kfqDxt5dTB1JhqsCUQVFDj0rmY+4HLwGQIsLPbyrsN9y9WV/1oFDSx3BQ4GfCv9X+jVeQ7rouTqwK53rA/7t8A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/web-resource-inliner/-/web-resource-inliner-8.0.0.tgz",
+      "integrity": "sha512-Ezr98sqXW/+OCGoUEXuOKVR+oVFlSdn1tIySEEJdiSAw4IjrW8hQkwARSSBJTSB5Us5dnytDgL0ZDliAYBhaNA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "escape-goat": "^3.0.0",
-        "htmlparser2": "^5.0.0",
+        "htmlparser2": "^9.1.0",
         "mime": "^2.4.6",
-        "node-fetch": "^2.6.0",
         "valid-data-url": "^3.0.0"
       },
       "engines": {
         "node": ">=10.0.0"
       }
     },
-    "node_modules/web-resource-inliner/node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/web-resource-inliner/node_modules/dom-serializer/node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/web-resource-inliner/node_modules/domhandler": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
-      "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "domelementtype": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/web-resource-inliner/node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/web-resource-inliner/node_modules/domutils/node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/web-resource-inliner/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/web-resource-inliner/node_modules/htmlparser2": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-5.0.1.tgz",
-      "integrity": "sha512-vKZZra6CSe9qsJzh0BjBGXo8dvzNsq/oGvsjfRdOrrryfeD9UOBEEQdeoqCRmKZchF5h2zOBMQ6YuQ0uRUmdbQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^3.3.0",
-        "domutils": "^2.4.2",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/htmlparser2?sponsor=1"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.1.0",
+        "entities": "^4.5.0"
       }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause",
-      "optional": true
     },
     "node_modules/webpack": {
       "version": "5.104.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -15729,15 +16440,41 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1152,7 +1152,6 @@
       "version": "7.28.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1802,7 +1801,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -1815,7 +1814,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2991,7 +2990,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -3009,7 +3008,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -3017,7 +3016,7 @@
     },
     "node_modules/@jridgewell/source-map": {
       "version": "0.3.11",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -3026,12 +3025,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3161,7 +3160,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.14.tgz",
       "integrity": "sha512-IN/tlqd7Nl9gl6f0jsWEuOrQDaCI9vHzxv0fisHysfBQzfQIkqlv5A7w4Qge02BUQyczXT9HHPgHtWHCxhjRng==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -3217,7 +3215,6 @@
       "integrity": "sha512-7OXPPMoDr6z+5NkoQKu4hOhfjz/YYqM3bNilPqv1WVFWrzSmuNXxvhbX69YMmNmRYascPXiwESqf5jJdjKXEww==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3277,7 +3274,6 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.14.tgz",
       "integrity": "sha512-Fs+/j+mBSBSXErOQJ/YdUn/HqJGSJ4pGfiJyYOyz04l42uNVnqEakvu1kXLbxMabR6vd6/h9d6Bi4tso9p7o4Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3532,7 +3528,6 @@
     "node_modules/@nestjs/typeorm": {
       "version": "11.0.0",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -3597,7 +3592,6 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3617,7 +3611,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.5.1.tgz",
       "integrity": "sha512-MHbu8XxCHcBn6RwvCt2Vpn1WnLMNECfNKYB14LI5XypcgH4IE0/DiVifVR9tAkwPMyLXN8dOoPJfya3IryLQVw==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -3630,7 +3623,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.1.tgz",
       "integrity": "sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -4066,7 +4058,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.1.tgz",
       "integrity": "sha512-BViBCdE/GuXRlp9k7nS1w6wJvY5fnFX5XvuEtWsTAOQFIO89Eru7lGW3WbfbxtCuZ/GbrJfAziXG0w0dpxL7eQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4083,7 +4074,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.1.tgz",
       "integrity": "sha512-iZH3Gw8cxQn0gjpOjJMmKLd9GIaNh/E3v3ST67vyzLSxHBs14HsG4dy7jMYyC5WXGdBVEcM7U/XTF5hCQxjDMw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.5.1",
         "@opentelemetry/resources": "2.5.1",
@@ -4099,7 +4089,6 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.39.0",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -5159,7 +5148,6 @@
       "version": "9.5.1",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@inquirer/prompts": "^8.0.0",
         "@stryker-mutator/api": "9.5.1",
@@ -5783,42 +5771,32 @@
       "version": "0.3.0",
       "license": "MIT"
     },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
       "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
       "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
       "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
@@ -5919,7 +5897,6 @@
       "version": "9.6.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -6076,7 +6053,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.1.tgz",
       "integrity": "sha512-hj9YIJimBCipHVfHKRMnvmHg+wfhKc0o4mTtXh9pKBjC8TLJzz0nzGmLi5UJsYAUgSvXFHgb0V2oY10DUFtImw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -6278,7 +6254,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -6918,7 +6893,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6958,7 +6932,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -6973,7 +6947,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7150,7 +7123,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -7522,7 +7495,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7804,7 +7776,6 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -7843,15 +7814,13 @@
     },
     "node_modules/class-transformer": {
       "version": "0.5.1",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
       "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -8173,7 +8142,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cron": {
@@ -8252,20 +8221,6 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/css-tree": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "mdn-data": "2.0.30",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-      }
-    },
     "node_modules/css-what": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -8290,6 +8245,27 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssnano": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.2.tgz",
+      "integrity": "sha512-HYOPBsNvoiFeR1eghKD5C3ASm64v9YVyJB4Ivnl2gqKoQYvjjN/G0rztvKQq8OxocUtC6sjqY8jwYngIB4AByA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cssnano-preset-default": "^7.0.10",
+        "lilconfig": "^3.1.3"
+      },
+      "engines": {
+        "node": "^18.12.0 || ^20.9.0 || >=22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/cssnano"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.32"
       }
     },
     "node_modules/cssnano-preset-default": {
@@ -8888,7 +8864,6 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -8943,7 +8918,6 @@
       "version": "10.1.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9216,7 +9190,6 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9258,7 +9231,6 @@
     "node_modules/express-rate-limit": {
       "version": "8.2.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ip-address": "10.0.1"
       },
@@ -10269,7 +10241,6 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.9.3.tgz",
       "integrity": "sha512-VI5tMCdeoxZWU5vjHWsiE/Su76JGhBvWF1MJnV9ZtGltHk9BmD48oDq8Tj8haZ85aceXZMxLNDQZRVo5QKNgXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.0",
         "cluster-key-slot": "^1.1.0",
@@ -10618,7 +10589,6 @@
       "version": "30.2.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -11697,7 +11667,7 @@
     },
     "node_modules/make-error": {
       "version": "1.3.6",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/makeerror": {
@@ -11714,13 +11684,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/mdn-data": {
-      "version": "2.0.30",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-      "license": "CC0-1.0",
-      "optional": true
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -12558,7 +12521,6 @@
     "node_modules/nodemailer": {
       "version": "8.0.1",
       "license": "MIT-0",
-      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -12907,7 +12869,6 @@
     "node_modules/passport": {
       "version": "0.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -13020,7 +12981,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.19.0.tgz",
       "integrity": "sha512-QIcLGi508BAHkQ3pJNptsFz5WQMlpGbuBGBaIaXsWK8mel2kQ/rThYI+DbgjUvZrIr7MiuEuc9LcChJoEZK1xQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.11.0",
         "pg-pool": "^3.12.0",
@@ -13190,6 +13150,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postcss-calc": {
@@ -13880,7 +13869,6 @@
       "version": "3.8.1",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14352,8 +14340,7 @@
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -14657,7 +14644,6 @@
     "node_modules/rxjs": {
       "version": "7.8.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -14955,7 +14941,7 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -14964,7 +14950,7 @@
     },
     "node_modules/source-map-support/node_modules/source-map": {
       "version": "0.6.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -15207,42 +15193,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/svgo": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.2.tgz",
-      "integrity": "sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@trysound/sax": "0.2.0",
-        "commander": "^7.2.0",
-        "css-select": "^5.1.0",
-        "css-tree": "^2.3.1",
-        "css-what": "^6.1.0",
-        "csso": "^5.0.5",
-        "picocolors": "^1.0.0"
-      },
-      "bin": {
-        "svgo": "bin/svgo"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/svgo"
-      }
-    },
-    "node_modules/svgo/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/swagger-ui-dist": {
       "version": "5.31.0",
       "license": "Apache-2.0",
@@ -15306,9 +15256,8 @@
     },
     "node_modules/terser": {
       "version": "5.44.1",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -15418,7 +15367,7 @@
     },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/test-exclude": {
@@ -15637,9 +15586,8 @@
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15682,7 +15630,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
       "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -15835,7 +15783,6 @@
     "node_modules/typeorm": {
       "version": "0.3.28",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -15978,9 +15925,8 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16177,7 +16123,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
@@ -16301,7 +16247,6 @@
       "version": "5.104.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -16624,7 +16569,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -142,10 +142,12 @@
     "eslint": {
       "ajv": "^6.14.0"
     },
-    "minimatch": "^10.2.2",
+    "minimatch": "^10.2.4",
     "test-exclude": "^8.0.0",
     "glob": "^13.0.0",
-    "html-minifier": "npm:html-minifier-terser@^7.2.0"
+    "html-minifier": "npm:html-minifier-terser@^7.2.0",
+    "fast-xml-parser": "^5.3.8",
+    "mjml": "^5.0.0-alpha.11"
   },
   "eslintConfig": {
     "root": true,

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "test-exclude": "^8.0.0",
     "glob": "^13.0.0",
     "html-minifier": "npm:html-minifier-terser@^7.2.0",
-    "fast-xml-parser": "^5.3.8",
+    "fast-xml-parser": "^5.4.1",
     "mjml": "^5.0.0-alpha.11"
   },
   "eslintConfig": {


### PR DESCRIPTION
## Description

This pull request introduces several enhancements to the continuous integration (CI) workflows and performs a comprehensive update of project dependencies. The dependency updates are primarily aimed at addressing identified security vulnerabilities and leveraging improvements from newer versions, including major upgrades for MJML and SVGO.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring
- [x] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation where necessary.
- [x] I have considered the security implications of these changes.
- [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

### CI Workflow Improvements
- Sets a dedicated `github-actions[bot]` identity for commits made by the contributors workflow, ensuring proper attribution.
- Enhances the DCO enforcement workflow by expanding bot detection to include commits where the author's name or email contains `[bot]`, improving accuracy for automated contributions.

### Dependency Updates
- Upgrades `minimatch` to `^10.2.4`.
- Upgrades `fast-xml-parser` to `^5.4.1`.
- Upgrades `mjml` and its associated components (e.g., `mjml-cli`, `mjml-core`, `mjml-preset-core`, `mjml-validator`) to `^5.0.0-alpha.11`. This includes significant internal changes such as replacing `html-minifier` with `htmlnano` and `postcss` for HTML and CSS optimisation.
- Upgrades `cheerio` from `1.0.0-rc.12` to `1.0.0`.
- Upgrades `juice` from `10.0.1` to `11.1.1`.
- Upgrades `svgo` to `^4.0.0`.
- Updates numerous other `@aws-sdk/*` packages and various minor/patch dependencies to resolve security vulnerabilities and incorporate general improvements.

## Breaking Changes

- **MJML v5.0.0-alpha.11**: This is a major version upgrade for MJML. While still in alpha, it introduces significant changes to its internal HTML and CSS optimisation processes (e.g., replacement of `html-minifier` with `htmlnano` and `postcss`). Users relying on specific behaviours or output from MJML v4 should review the MJML v5 changelog for potential breaking changes and necessary migration steps.
- **SVGO v4.0.0**: This is a major version upgrade for SVGO. Consumers of SVG optimisation might experience changes in output or require updates to their configuration due to new features or altered defaults in SVGO v4.

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk