### PR TITLE
ci(workflows): Prevents redundant automated updates

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -13,11 +13,50 @@ env:
 permissions: {}
 
 jobs:
+  check_eligibility:
+    name: Check eligibility
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.decide.outputs.should_run }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Decide whether to run
+        id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT_REPO_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+
+          # 1. Skip if it's a version bump or contributors commit (mutual exclusion)
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          if [[ "$COMMIT_MSG" == *"chore: bump version to"* ]] || [[ "$COMMIT_MSG" == *"docs: update contributors"* ]]; then
+            echo "Skipping: restricted commit message detected."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 2. Skip if a contributors PR is already open
+          EXISTING_PR=$(gh pr list --base development --search "docs: update contributors in:title" --json number --jq '.[0].number' || echo "")
+          if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
+            echo "Skipping: PR #$EXISTING_PR is already open."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+
   update-contributors:
     name: Update Contributors
+    needs: check_eligibility
+    if: |
+      needs.check_eligibility.outputs.should_run == 'true' &&
+      (github.repository_owner == 'sto-info-app' || github.event.repository.fork == false)
     runs-on: ubuntu-latest
-    # Run only on the canonical repository
-    if: github.repository_owner == 'sto-info-app' || github.event.repository.fork == false
     permissions:
       contents: write
       pull-requests: write
@@ -32,8 +71,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          BRANCH_NAME="chore/update-contributors-${{ github.run_id }}"
-          git checkout -b "$BRANCH_NAME"
+          BRANCH_NAME="chore/update-contributors"
+          git checkout -B "$BRANCH_NAME"
           echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
 
       - name: Setup Node.js

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -62,6 +62,7 @@ jobs:
       needs.check_changes.outputs.src_changed == 'true' &&
       github.actor != 'github-actions[bot]' &&
       !startsWith(github.event.head_commit.message, 'chore: bump version to ') &&
+      !startsWith(github.event.head_commit.message, 'docs: update contributors') &&
       !contains(github.event.head_commit.message, 'Automated version bump from') &&
       !(contains(github.event.head_commit.message, 'Merge pull request') && contains(github.event.head_commit.message, 'chore/bump-version-to'))
 


### PR DESCRIPTION
## Description

This change introduces intelligent skipping logic across the automated CI workflows for contributor updates and version bumps.

For the `contributors.yml` workflow, a new `check_eligibility` job has been added. This job determines if the contributor update process should proceed by:
- Skipping if the triggering commit message indicates a version bump or a previous contributor update.
- Skipping if an existing pull request titled "docs: update contributors" is already open.
These checks ensure that redundant pull requests are not created and prevent conflicts with other automated processes. The workflow also now uses a consistent branch name, `chore/update-contributors`, which is reset if it already exists, streamlining the process.

For the `version-bump.yml` workflow, an exclusion has been added to prevent it from running when the triggering commit is for a contributor update. This avoids unnecessary or incorrect version bumps for purely documentation-related changes.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [x] ci
- [ ] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation where necessary.
- [ ] I have considered the security implications of these changes.
- [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

No breaking changes are introduced by these modifications.

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>