### PR TITLE
ci(zap-workflows): Improves API health check reliability

### DIFF
--- a/.github/workflows/security-zap-dev.yml
+++ b/.github/workflows/security-zap-dev.yml
@@ -24,7 +24,7 @@ permissions: {}
 env:
   NODE_VERSION: 24
   DEV_API_BASE_URL: 'https://dev-api.startrekonline.info'
-  DEV_API_HEALTH_URL: 'https://dev-api.startrekonline.info/health'
+  DEV_API_HEALTH_URL: 'https://dev-api.startrekonline.info/health/live'
   DEV_API_VERSION_URL: 'https://dev-api.startrekonline.info/version'
 
 concurrency:
@@ -64,7 +64,7 @@ jobs:
           echo "Expected repo version: ${expected_version}"
           echo "version_matched=false" >> "$GITHUB_OUTPUT"
 
-          status_hook=$(curl -s -o /dev/null -w "%{http_code}" -H "User-Agent: Mozilla/5.0" --proto '=https' --proto-redir '=https' "${DEV_API_HEALTH_URL}/live" --max-time 10 || echo "000")
+          status_hook=$(curl -s -o /dev/null -w "%{http_code}" -H "User-Agent: Mozilla/5.0" --proto '=https' --proto-redir '=https' "${DEV_API_HEALTH_URL}" --max-time 10 || echo "000")
           if [ "$status_hook" = "403" ]; then
             echo "::warning::403 Forbidden: Requests from GitHub Actions are being blocked. Allow GitHub Actions IP ranges for ${DEV_API_HEALTH_URL}."
             echo "Allowing workflow to proceed as this might be a generic bot block; ZAP might still be able to scan."
@@ -102,7 +102,7 @@ jobs:
 
           echo "Waiting for API to be reachable..."
           for attempt in $(seq 1 $max_attempts); do
-            status_hook=$(curl -s -o /dev/null -w "%{http_code}" -H "User-Agent: Mozilla/5.0" --proto '=https' --proto-redir '=https' "${DEV_API_HEALTH_URL}/live" || echo "000")
+            status_hook=$(curl -s -o /dev/null -w "%{http_code}" -H "User-Agent: Mozilla/5.0" --proto '=https' --proto-redir '=https' "${DEV_API_HEALTH_URL}" || echo "000")
             if [ "$status_hook" = "200" ]; then
               echo "API is live ($status_hook)"
               break
@@ -152,9 +152,9 @@ jobs:
         if: github.event_name == 'push' || github.event.inputs.zap_scan_type == 'baseline'
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
         with:
-          target: ${{ env.DEV_API_HEALTH_URL }}/live
+          target: ${{ env.DEV_API_HEALTH_URL }}
           rules_file_name: '.zap/rules.tsv'
-          cmd_options: '-a -j -m 3 -T 900'
+          cmd_options: '-H "User-Agent: Mozilla/5.0" -a -j -m 3 -T 900'
           allow_issue_writing: false
           artifact_name: zap-baseline-report-dev-api
 
@@ -164,6 +164,6 @@ jobs:
         with:
           target: ${{ env.DEV_API_BASE_URL }}
           rules_file_name: '.zap/rules.tsv'
-          cmd_options: '-a -j -m 3 -T 1800'
+          cmd_options: '-H "User-Agent: Mozilla/5.0" -a -j -m 3 -T 1800'
           allow_issue_writing: false
           artifact_name: zap-full-scan-report-dev-api

--- a/.github/workflows/security-zap-prod.yml
+++ b/.github/workflows/security-zap-prod.yml
@@ -23,7 +23,7 @@ permissions: {}
 env:
   NODE_VERSION: 24
   PROD_API_BASE_URL: 'https://api.startrekonline.info'
-  PROD_API_HEALTH_URL: 'https://api.startrekonline.info/health'
+  PROD_API_HEALTH_URL: 'https://api.startrekonline.info/health/live'
   PROD_API_VERSION_URL: 'https://api.startrekonline.info/version'
 
 concurrency:
@@ -62,7 +62,7 @@ jobs:
           echo "Expected repo version: ${expected_version}"
           echo "version_matched=false" >> "$GITHUB_OUTPUT"
 
-          status_hook=$(curl -s -o /dev/null -w "%{http_code}" --proto '=https' --proto-redir '=https' "${PROD_API_HEALTH_URL}/live" --max-time 10 || echo "000")
+          status_hook=$(curl -s -o /dev/null -w "%{http_code}" -H "User-Agent: Mozilla/5.0" --proto '=https' --proto-redir '=https' "${PROD_API_HEALTH_URL}" --max-time 10 || echo "000")
           if [ "$status_hook" = "403" ]; then
             echo "::error::403 Forbidden: Requests from GitHub Actions are being blocked. Allow GitHub Actions IP ranges for ${PROD_API_HEALTH_URL}. See https://docs.github.com/en/actions/security-guides/using-github-actions-from-github-hosted-runners#ip-addresses-for-github-hosted-runners"
             exit 1
@@ -72,7 +72,7 @@ jobs:
             exit 0
           fi
 
-          version_response=$(curl -sSL -w "\n%{http_code}" --proto '=https' --proto-redir '=https' "${PROD_API_VERSION_URL}" --max-time 10 2>/dev/null || true)
+          version_response=$(curl -sSL -w "\n%{http_code}" -H "User-Agent: Mozilla/5.0" --proto '=https' --proto-redir '=https' "${PROD_API_VERSION_URL}" --max-time 10 2>/dev/null || true)
           http_code=$(echo "${version_response}" | tail -n1)
           actual_version=$(echo "${version_response}" | sed '$d' | tr -d '\r\n')
 
@@ -100,7 +100,7 @@ jobs:
 
           echo "Waiting for API to be reachable..."
           for attempt in $(seq 1 $max_attempts); do
-            status_hook=$(curl -s -o /dev/null -w "%{http_code}" --proto '=https' --proto-redir '=https' "${PROD_API_HEALTH_URL}/live" || echo "000")
+            status_hook=$(curl -s -o /dev/null -w "%{http_code}" -H "User-Agent: Mozilla/5.0" --proto '=https' --proto-redir '=https' "${PROD_API_HEALTH_URL}" || echo "000")
             if [ "$status_hook" = "200" ]; then
               echo "API is live ($status_hook)"
               break
@@ -116,7 +116,7 @@ jobs:
           done
 
           for attempt in $(seq 1 $max_attempts); do
-            version_response=$(curl -sSL -w "\n%{http_code}" --proto '=https' --proto-redir '=https' "${PROD_API_VERSION_URL}" 2>/dev/null || true)
+            version_response=$(curl -sSL -w "\n%{http_code}" -H "User-Agent: Mozilla/5.0" --proto '=https' --proto-redir '=https' "${PROD_API_VERSION_URL}" 2>/dev/null || true)
             http_code=$(echo "${version_response}" | tail -n1)
             actual_version=$(echo "${version_response}" | sed '$d' | tr -d '\r\n')
 
@@ -149,9 +149,9 @@ jobs:
         if: github.event_name == 'push' || github.event.inputs.zap_scan_type == 'baseline'
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
         with:
-          target: ${{ env.PROD_API_HEALTH_URL }}/live
+          target: ${{ env.PROD_API_HEALTH_URL }}
           rules_file_name: '.zap/rules.tsv'
-          cmd_options: '-a -j -m 3 -T 900'
+          cmd_options: '-H "User-Agent: Mozilla/5.0" -a -j -m 3 -T 900'
           allow_issue_writing: false
           artifact_name: zap-baseline-report-prod-api
 
@@ -161,6 +161,6 @@ jobs:
         with:
           target: ${{ env.PROD_API_BASE_URL }}
           rules_file_name: '.zap/rules.tsv'
-          cmd_options: '-a -j -m 3 -T 1800'
+          cmd_options: '-H "User-Agent: Mozilla/5.0" -a -j -m 3 -T 1800'
           allow_issue_writing: false
           artifact_name: zap-full-scan-report-prod-api


### PR DESCRIPTION
## Description

The changes in this pull request focus on enhancing the reliability of API health checks and ZAP security scans within the CI/CD workflows for both development and production environments. This is achieved by:
- Adjusting the `DEV_API_HEALTH_URL` and `PROD_API_HEALTH_URL` environment variables to consistently point directly to the `/health/live` endpoint.
- Updating `curl` commands to reflect this change, ensuring the correct health endpoint is always targeted without redundancy.
- Integrating a `User-Agent: Mozilla/5.0` header into all `curl` requests performed in the workflows, as well as into the ZAP baseline and full scan commands. This helps prevent requests from being blocked by web application firewalls or bot detection mechanisms, which often block requests originating from generic or absent user agents. These modifications collectively aim to reduce transient failures and provide more accurate health status and scan results.

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Documentation update
- [X] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [X] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation where necessary.
- [X] I have considered the security implications of these changes.
- [X] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

The addition of the `User-Agent` header is a crucial step to ensure that automated requests from GitHub Actions are treated as legitimate browser traffic by the API's security measures, thereby unblocking health checks and allowing ZAP scans to complete successfully.

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>