### PR TITLE
fix(ci): Corrects ZAP user agent configuration

### DIFF
--- a/.github/workflows/security-zap-dev.yml
+++ b/.github/workflows/security-zap-dev.yml
@@ -154,7 +154,7 @@ jobs:
         with:
           target: ${{ env.DEV_API_HEALTH_URL }}
           rules_file_name: '.zap/rules.tsv'
-          cmd_options: '-H "User-Agent: Mozilla/5.0" -a -j -m 3 -T 900'
+          cmd_options: '-z "-config network.connection.defaultUserAgent=Mozilla/5.0" -a -j -m 3 -T 900'
           allow_issue_writing: false
           artifact_name: zap-baseline-report-dev-api
 
@@ -164,6 +164,6 @@ jobs:
         with:
           target: ${{ env.DEV_API_BASE_URL }}
           rules_file_name: '.zap/rules.tsv'
-          cmd_options: '-H "User-Agent: Mozilla/5.0" -a -j -m 3 -T 1800'
+          cmd_options: '-z "-config network.connection.defaultUserAgent=Mozilla/5.0" -a -j -m 3 -T 1800'
           allow_issue_writing: false
           artifact_name: zap-full-scan-report-dev-api

--- a/.github/workflows/security-zap-prod.yml
+++ b/.github/workflows/security-zap-prod.yml
@@ -151,7 +151,7 @@ jobs:
         with:
           target: ${{ env.PROD_API_HEALTH_URL }}
           rules_file_name: '.zap/rules.tsv'
-          cmd_options: '-H "User-Agent: Mozilla/5.0" -a -j -m 3 -T 900'
+          cmd_options: '-z "-config network.connection.defaultUserAgent=Mozilla/5.0" -a -j -m 3 -T 900'
           allow_issue_writing: false
           artifact_name: zap-baseline-report-prod-api
 
@@ -161,6 +161,6 @@ jobs:
         with:
           target: ${{ env.PROD_API_BASE_URL }}
           rules_file_name: '.zap/rules.tsv'
-          cmd_options: '-H "User-Agent: Mozilla/5.0" -a -j -m 3 -T 1800'
+          cmd_options: '-z "-config network.connection.defaultUserAgent=Mozilla/5.0" -a -j -m 3 -T 1800'
           allow_issue_writing: false
           artifact_name: zap-full-scan-report-prod-api


### PR DESCRIPTION
## Description

Removes the invalid `-H` option for setting the User-Agent header in the OWASP ZAP security scanning workflows. It replaces it with the correct `-z "-config network.connection.defaultUserAgent=Mozilla/5.0"` syntax for both development and production API environments. This change ensures that the ZAP scanner accurately sets the User-Agent, improving the effectiveness and validity of the security scans.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation where necessary.
- [x] I have considered the security implications of these changes.
- [x] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes


Signed-off-by: Steve Roberts