### PR TITLE
fix(ci): Enhance automated release notes and creation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -17,7 +17,19 @@ changelog:
       labels:
         - chore
         - refactor
+        - dependencies
     - title: 🧪 Testing
       labels:
         - test
         - testing
+    - title: 📖 Documentation
+      labels:
+        - documentation
+        - docs
+    - title: ⚙️ CI/CD
+      labels:
+        - ci
+        - ci-cd
+        - github-actions
+    - title: 🔩 Other Changes
+      labels: []

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -48,38 +48,36 @@ jobs:
               const sha = c.sha;
               const message = (c.commit && c.commit.message) ? c.commit.message : '';
               const isMerge = c.parents && c.parents.length > 1;
-              const isBot = (c.author && c.author.type === 'Bot') ||
-                            (c.committer && c.committer.type === 'Bot') ||
-                            (c.author && c.author.login && c.author.login.toLowerCase().includes('[bot]')) ||
-                            (c.committer && c.committer.login && c.committer.login.toLowerCase().includes('[bot]')) ||
-                            (c.commit && c.commit.author && (
-                              (c.commit.author.name && (
-                                c.commit.author.name.toLowerCase().includes('[bot]') || 
-                                c.commit.author.name.toLowerCase().includes('github-actions')
-                              )) ||
-                              (c.commit.author.email && (
-                                c.commit.author.email.toLowerCase().includes('[bot]') || 
-                                c.commit.author.email.toLowerCase().includes('github-actions')
-                              ))
-                            )) ||
-                            (c.commit && c.commit.committer && (
-                              (c.commit.committer.name && (
-                                c.commit.committer.name.toLowerCase().includes('[bot]') || 
-                                c.commit.committer.name.toLowerCase().includes('github-actions')
-                              )) ||
-                              (c.commit.committer.email && (
-                                c.commit.committer.email.toLowerCase().includes('[bot]') || 
-                                c.commit.committer.email.toLowerCase().includes('github-actions')
-                              ))
-                            ));
+              
+              const authorData = (c.commit && c.commit.author) ? c.commit.author : {};
+              const committerData = (c.commit && c.commit.committer) ? c.commit.committer : {};
+              const authorEmail = (authorData.email || '').toLowerCase();
+              const committerEmail = (committerData.email || '').toLowerCase();
+              const authorName = (authorData.name || '').toLowerCase();
+
+              // Detect if the commit is from a bot (GitHub bot or email convention)
+              const isBot = (c.author && c.author.type === 'Bot') || 
+                            authorEmail.includes('[bot]') || 
+                            committerEmail.includes('[bot]') || 
+                            authorName.includes('[bot]') ||
+                            authorEmail === 'github-actions[bot]@users.noreply.github.com';
 
               if (isMerge || isBot) {
                 continue;
               }
 
-              const signoffs = getSignoffs(message);
-              if (signoffs.length === 0) {
+              const signoffs = getSignoffs(message).filter(sig => 
+                !sig.email.includes('[bot]') && 
+                !sig.name.toLowerCase().includes('[bot]') &&
+                sig.email !== 'github-actions[bot]@users.noreply.github.com'
+              );
+              
+              if (signoffs.length === 0 && !isBot) {
                 failures.push(`- ${sha}: The sign-off is missing.`);
+                continue;
+              }
+              
+              if (isBot) {
                 continue;
               }
 

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [production]
 
+# Declare default permissions as read only.
 permissions: {}
 
 env:
@@ -18,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      contents: write
-      pull-requests: write
+      contents: write # To create and push tags
+      pull-requests: write # To unmask the last version bump PR
 
     steps:
       - name: Checkout repo
@@ -54,19 +55,51 @@ jobs:
           git tag -a "$TAG_NAME" -m "Release $TAG_NAME"
           git push origin "$TAG_NAME"
 
-      - name: Unmask last version bump in release notes
+      - name: Prepare PRs for release notes
         env:
-          GH_TOKEN: ${{ secrets.GH_PAT_REPO_TOKEN || github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          echo "Finding PR for version $VERSION..."
+          echo "Processing PRs for version $VERSION..."
 
-          # Search for the merged version bump PR
-          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --state merged --search "chore: bump version to $VERSION" --json number --jq '.[0].number' || echo "")
-
-          if [ -n "$PR_NUMBER" ]; then
-            echo "Removing 'version-bump' label from PR #$PR_NUMBER to include it in release notes."
-            gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --remove-label version-bump || echo "Failed to remove label, but continuing..."
-          else
-            echo "No matching version bump PR found for version $VERSION."
+          # 1. Unmask the specific version bump PR for this release
+          BUMP_PR=$(gh pr list --repo "${{ github.repository }}" --state all --limit 1 --search "chore: bump version to $VERSION" --json number --jq '.[0].number' || echo "")
+          if [ -n "$BUMP_PR" ] && [ "$BUMP_PR" != "null" ]; then
+            echo "Unmasking version bump PR #$BUMP_PR (removing version-bump label)"
+            gh pr edit "$BUMP_PR" --repo "${{ github.repository }}" --remove-label version-bump || true
           fi
+
+          # 2. Auto-label unlabeled PRs based on Conventional Commit prefixes
+          # This ensures they are correctly categorised in the release notes
+          echo "Scanning recent PRs for missing labels..."
+          gh pr list --repo "${{ github.repository }}" --state merged --limit 50 --json number,title,labels --jq '.[] | select(.labels|length == 0) | "\(.number)|\(.title)"' | while read -r line; do
+            PR_NUM=$(echo "$line" | cut -d'|' -f1)
+            PR_TITLE=$(echo "$line" | cut -d'|' -f2)
+            
+            LABEL=""
+            case "${PR_TITLE,,}" in # Convert to lowercase for matching
+              feat*)     LABEL="feature" ;;
+              fix*)      LABEL="fix" ;;
+              chore*)    LABEL="chore" ;;
+              docs*)     LABEL="documentation" ;;
+              test*)     LABEL="test" ;;
+              ci*)       LABEL="ci" ;;
+              refactor*) LABEL="refactor" ;;
+            esac
+            
+            if [ -n "$LABEL" ]; then
+              echo "Auto-labeling PR #$PR_NUM as '$LABEL' based on title: $PR_TITLE"
+              gh pr edit "$PR_NUM" --repo "${{ github.repository }}" --add-label "$LABEL" || true
+            fi
+          done
+
+      - name: Create Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: Release v${{ steps.version.outputs.version }}
+          generate_release_notes: true
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Description

This pull request refines the automated GitHub release process by enhancing the accuracy and categorisation of release notes and by automating the release creation itself. It introduces new changelog categories in `release.yml`, implements a mechanism to automatically label merged pull requests based on their Conventional Commit titles within `tag-release.yml`, and integrates the official GitHub release action to publish new versions. This ensures comprehensive and well-structured release notes are generated for each new version, addressing previous inconsistencies where PRs might lack appropriate labels. Explicit permissions comments have also been added for clarity.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [x] Documentation update
- [x] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [x] I have updated the documentation where necessary.
- [x] I have considered the security implications of these changes.
- [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

Previously, release notes could be inconsistent due to missing labels on pull requests or an inability to properly categorise all types of changes. This update addresses these inconsistencies by automatically assigning labels to recently merged pull requests based on their Conventional Commit prefixes, improving the quality and completeness of the generated changelog. The release creation is now fully automated, utilising the `softprops/action-gh-release` to publish new versions directly to GitHub Releases. The use of `secrets.GITHUB_TOKEN` is standardised, and explicit comments clarify workflow permissions.

Relates to SC-905

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>