### PR TITLE
fix(ci): Refines DCO check logic for bot commits

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -55,31 +55,32 @@ jobs:
               const committerEmail = (committerData.email || '').toLowerCase();
               const authorName = (authorData.name || '').toLowerCase();
 
-              // Detect if the commit is from a bot (GitHub bot or email convention)
+              const allSignoffs = getSignoffs(message);
+              const humanSignoffs = allSignoffs.filter(sig => 
+                !sig.email.toLowerCase().includes('[bot]') && 
+                !sig.name.toLowerCase().includes('[bot]') &&
+                !sig.email.toLowerCase().includes('github-actions') &&
+                !sig.email.toLowerCase().endsWith('@users.noreply.github.com')
+              );
+
+              // Detect if the commit is from a bot (GitHub bot, email convention, or PURELY bot sign-offs)
               const isBot = (c.author && c.author.type === 'Bot') || 
                             authorEmail.includes('[bot]') || 
                             committerEmail.includes('[bot]') || 
                             authorName.includes('[bot]') ||
-                            authorEmail === 'github-actions[bot]@users.noreply.github.com';
+                            authorEmail === 'github-actions[bot]@users.noreply.github.com' ||
+                            (allSignoffs.length > 0 && humanSignoffs.length === 0);
 
               if (isMerge || isBot) {
                 continue;
               }
 
-              const signoffs = getSignoffs(message).filter(sig => 
-                !sig.email.includes('[bot]') && 
-                !sig.name.toLowerCase().includes('[bot]') &&
-                sig.email !== 'github-actions[bot]@users.noreply.github.com'
-              );
-              
-              if (signoffs.length === 0 && !isBot) {
+              if (humanSignoffs.length === 0) {
                 failures.push(`- ${sha}: The sign-off is missing.`);
                 continue;
               }
-              
-              if (isBot) {
-                continue;
-              }
+
+              const signoffs = humanSignoffs;
 
               const author = (c.commit && c.commit.author) ? c.commit.author : {};
               const committer = (c.commit && c.commit.committer) ? c.commit.committer : {};


### PR DESCRIPTION
## Description

Refines the DCO (Developer Certificate of Origin) check logic within the CI workflow to improve its robustness against bot commits. This change addresses instances where bot commits were incorrectly triggering DCO failures or being misattributed. The updated logic introduces a more stringent filtering for "human" sign-offs and classifies a commit as bot-driven if all included sign-offs originate from bot accounts, even if the primary author/committer details might appear human.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation where necessary.
- [ ] I have considered the security implications of these changes.
- [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

Relates to SC-905

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>