### PR TITLE
chore(security): enhance dependency security and documentation

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -33,7 +33,8 @@ Current overrides in `package.json`:
   "glob": "^13.0.0",
   "fast-xml-parser": "^5.4.1",
   "mjml": "^5.0.0-alpha.11",
-  "serialize-javascript": "^7.0.3"
+  "serialize-javascript": "^7.0.3",
+  "underscore": "^1.13.8"
 }
 ```
 
@@ -44,13 +45,15 @@ Current overrides in `package.json`:
 - **Override**: `"@nestjs/platform-express": { "multer": "^2.1.1" }` — targets only the nested copy inside `@nestjs/platform-express`.
 - **npm 11.x limitation**: npm 11.x does not apply nested overrides when the same package also exists as a direct dependency at the top level. As a result, the nested `multer` is patched automatically on every install by the `postinstall` hook (see below).
 
-**When it can be removed**: When `@nestjs/platform-express` updates its own `multer` dependency to `>= 2.1.1`. Check by running:
+**When it can be removed**: When `@nestjs/platform-express` updates its own `multer` dependency to a range `>= 2.1.1` (not an exact pin). Check by running:
 
 ```sh
 npm view @nestjs/platform-express@latest dependencies.multer
 ```
 
-If that returns `>= 2.1.1`, remove both the nested override and the `multer` patch entry from `scripts/patch-nested-packages.js`.
+> **Current status (as of v11.1.16):** `@nestjs/platform-express` now pins `multer` to exactly `2.1.1` (the safe version), so the security vulnerability is addressed upstream. The override is kept in place so future patch releases of `multer` are picked up automatically rather than being locked to a single exact version. The postinstall patch in `scripts/patch-nested-packages.js` remains in place for the same reason.
+
+Remove both the nested override and the `multer` patch entry from `scripts/patch-nested-packages.js` when `@nestjs/platform-express` switches from an exact pin to a range `>= 2.1.1`.
 
 #### `ajv` overrides
 
@@ -96,6 +99,19 @@ If that returns `>= 2.1.1`, remove both the nested override and the `multer` pat
 - **Solution**: Override to `^7.0.3`.
 
 **When it can be removed**: When `terser-webpack-plugin` updates its own `serialize-javascript` dependency to `>= 7.0.3`.
+
+#### `underscore`
+
+- **Vulnerability**: [GHSA-qpx9-hpmf-5gmw](https://github.com/advisories/GHSA-qpx9-hpmf-5gmw) — Denial of Service via uncontrolled recursion in `underscore < 1.13.8`. The `_.flatten` and `_.isEqual` functions have no recursion depth limit; a deeply nested input (~4,500+ levels) triggers a `RangeError: Maximum call stack size exceeded`, crashing the process. CVSS 8.2 (High).
+- **Root cause**: `@stryker-mutator/core` (devDependency) pulls in `typed-rest-client ~2.2.0`, which depends on `underscore ^1.12.1`, resolving to `1.13.7`.
+- **Scope**: devDependency chain only — this vulnerability is not present in the production dependency tree and would not be flagged by `npm audit --omit=dev`. It is flagged by GitHub's OSV/Scorecard scanner, which scans the full lock file.
+- **Solution**: Override to `^1.13.8`.
+
+**When it can be removed**: When `typed-rest-client` updates its own `underscore` dependency to `>= 1.13.8`. Check by running:
+
+```sh
+npm view typed-rest-client@latest dependencies.underscore
+```
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -389,16 +389,16 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1003.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1003.0.tgz",
-      "integrity": "sha512-on8GvIWeH1pD0l53NuKbPO84bEC1mk/9zskgU+dVKcVoGxOZI94fVddCJb+IwIUN6rfBHCfXPCVbgVyzsHTAVg==",
+      "version": "3.1004.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1004.0.tgz",
+      "integrity": "sha512-m0zNfpsona9jQdX1cHtHArOiuvSGZPsgp/KRZS2YjJhKah96G2UN3UNGZQ6aVjXIQjCY6UanCJo0uW9Xf2U41w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/core": "^3.973.18",
-        "@aws-sdk/credential-provider-node": "^3.972.17",
+        "@aws-sdk/credential-provider-node": "^3.972.18",
         "@aws-sdk/middleware-bucket-endpoint": "^3.972.7",
         "@aws-sdk/middleware-expect-continue": "^3.972.7",
         "@aws-sdk/middleware-flexible-checksums": "^3.973.4",
@@ -408,13 +408,13 @@
         "@aws-sdk/middleware-recursion-detection": "^3.972.7",
         "@aws-sdk/middleware-sdk-s3": "^3.972.18",
         "@aws-sdk/middleware-ssec": "^3.972.7",
-        "@aws-sdk/middleware-user-agent": "^3.972.18",
+        "@aws-sdk/middleware-user-agent": "^3.972.19",
         "@aws-sdk/region-config-resolver": "^3.972.7",
         "@aws-sdk/signature-v4-multi-region": "^3.996.6",
         "@aws-sdk/types": "^3.973.5",
         "@aws-sdk/util-endpoints": "^3.996.4",
         "@aws-sdk/util-user-agent-browser": "^3.972.7",
-        "@aws-sdk/util-user-agent-node": "^3.973.3",
+        "@aws-sdk/util-user-agent-node": "^3.973.4",
         "@smithy/config-resolver": "^4.4.10",
         "@smithy/core": "^3.23.8",
         "@smithy/eventstream-serde-browser": "^4.2.11",
@@ -1128,6 +1128,8 @@
     },
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
+      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -1148,8 +1150,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1158,10 +1158,9 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1189,8 +1188,6 @@
     },
     "node_modules/@babel/core/node_modules/@babel/code-frame": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1212,8 +1209,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1229,8 +1224,6 @@
     },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1242,8 +1235,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1259,8 +1250,6 @@
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1269,8 +1258,6 @@
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
-      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1291,8 +1278,6 @@
     },
     "node_modules/@babel/helper-create-class-features-plugin/node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1309,8 +1294,6 @@
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
-      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1351,8 +1334,6 @@
     },
     "node_modules/@babel/helper-optimise-call-expression": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
-      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1372,8 +1353,6 @@
     },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
-      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1390,8 +1369,6 @@
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
-      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1420,8 +1397,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1430,8 +1405,6 @@
     },
     "node_modules/@babel/helpers": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1444,8 +1417,6 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1460,8 +1431,6 @@
     },
     "node_modules/@babel/plugin-proposal-decorators": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.29.0.tgz",
-      "integrity": "sha512-CVBVv3VY/XRMxRYq5dwr2DS7/MvqPm23cOCjbwNnVrfOqcWlnefua1uUs0sjdKOGjvPUG633o07uWzJq4oI6dA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1525,8 +1494,6 @@
     },
     "node_modules/@babel/plugin-syntax-decorators": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.28.6.tgz",
-      "integrity": "sha512-71EYI0ONURHJBL4rSFXnITXqXrrY8q4P0q006DPfN+Rk+ASM+++IBXem/ruokgBZR8YNEWZ8R6B+rCb8VcUTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1699,8 +1666,6 @@
     },
     "node_modules/@babel/plugin-transform-destructuring": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
-      "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1716,8 +1681,6 @@
     },
     "node_modules/@babel/plugin-transform-explicit-resource-management": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
-      "integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1733,8 +1696,6 @@
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
-      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1750,8 +1711,6 @@
     },
     "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
-      "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1770,8 +1729,6 @@
     },
     "node_modules/@babel/preset-typescript": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
-      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1790,8 +1747,6 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1813,8 +1768,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1832,8 +1785,6 @@
     },
     "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1847,8 +1798,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1883,8 +1832,6 @@
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1896,8 +1843,6 @@
     },
     "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1907,8 +1852,6 @@
     },
     "node_modules/@css-inline/css-inline": {
       "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@css-inline/css-inline/-/css-inline-0.14.1.tgz",
-      "integrity": "sha512-u4eku+hnPqqHIGq/ZUQcaP0TrCbYeLIYBaK7qClNRGZbnh8RC4gVxLEIo8Pceo1nOK9E5G4Lxzlw5KnXcvflfA==",
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -2072,8 +2015,6 @@
     },
     "node_modules/@css-inline/css-inline-win32-x64-msvc": {
       "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@css-inline/css-inline-win32-x64-msvc/-/css-inline-win32-x64-msvc-0.14.1.tgz",
-      "integrity": "sha512-nzotGiaiuiQW78EzsiwsHZXbxEt6DiMUFcDJ6dhiliomXxnlaPyBfZb6/FMBgRJOf6sknDt/5695OttNmbMYzg==",
       "cpu": [
         "x64"
       ],
@@ -2151,8 +2092,6 @@
     },
     "node_modules/@eslint/config-array": {
       "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.2.tgz",
-      "integrity": "sha512-YF+fE6LV4v5MGWRGj7G404/OZzGNepVF8fxk7jqmqo3lrza7a0uUcDnROGRBG1WFC1omYUS/Wp1f42i0M+3Q3A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2166,8 +2105,6 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.2.tgz",
-      "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2179,8 +2116,6 @@
     },
     "node_modules/@eslint/core": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2192,8 +2127,6 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.2.tgz",
-      "integrity": "sha512-HOy56KJt48Bx8KmJ+XGQNSUMT/6dZee/M54XyUyuvTvPXJmsERRvBchsUVx1UMe1WwIH49XLAczNC7V2INsuUw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -2202,8 +2135,6 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.0.tgz",
-      "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2216,8 +2147,6 @@
     },
     "node_modules/@fastify/otel": {
       "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.16.0.tgz",
-      "integrity": "sha512-2304BdM5Q/kUvQC9qJO1KZq3Zn1WWsw+WWkVmFEaj1UE2hEIiuFqrPeglQOwEtw/ftngisqfQ3v70TWMmwhhHA==",
       "funding": [
         {
           "type": "github",
@@ -2241,8 +2170,6 @@
     },
     "node_modules/@fastify/otel/node_modules/@opentelemetry/api-logs": {
       "version": "0.208.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
-      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -2253,8 +2180,6 @@
     },
     "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation": {
       "version": "0.208.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.208.0.tgz",
-      "integrity": "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.208.0",
@@ -2665,8 +2590,6 @@
     },
     "node_modules/@ioredis/commands": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
-      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
       "license": "MIT"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -3149,8 +3072,6 @@
     },
     "node_modules/@nestjs-modules/mailer": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@nestjs-modules/mailer/-/mailer-2.0.2.tgz",
-      "integrity": "sha512-+z4mADQasg0H1ZaGu4zZTuKv2pu+XdErqx99PLFPzCDNTN/q9U59WPgkxVaHnsvKHNopLj5Xap7G4ZpptduoYw==",
       "license": "MIT",
       "dependencies": {
         "@css-inline/css-inline": "0.14.1",
@@ -3184,8 +3105,6 @@
     },
     "node_modules/@nestjs-modules/mailer/node_modules/ejs": {
       "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -3246,6 +3165,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.16.tgz",
       "integrity": "sha512-JSIeW+USuMJkkcNbiOdcPkVCeI3TSnXstIVEPpp3HiaKnPRuSbUUKm9TY9o/XpIcPHWUOQItAtC5BiAwFdVITQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -3301,6 +3221,7 @@
       "integrity": "sha512-tXWXyCiqWthelJjrE0KLFjf0O98VEt+WPVx5CrqCf+059kIxJ8y1Vw7Cy7N4fwQafWNrmFL2AfN87DDMbVAY0w==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3360,6 +3281,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.16.tgz",
       "integrity": "sha512-IOegr5+ZfUiMKgk+garsSU4MOkPRhm46e6w8Bp1GcO4vCdl9Piz6FlWAzKVfa/U3Hn/DdzSVJOW3TWcQQFdBDw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3486,8 +3408,6 @@
     },
     "node_modules/@nestjs/swagger/node_modules/@nestjs/mapped-types": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
-      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
       "license": "MIT",
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
@@ -3506,8 +3426,6 @@
     },
     "node_modules/@nestjs/terminus": {
       "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@nestjs/terminus/-/terminus-11.1.1.tgz",
-      "integrity": "sha512-Ssql79H+EQY/Wg108eJqN4NiNsO/tLrj+qbzOWSQUf2JE4vJQ2RG3WTqUOrYjfjWmVHD3+Ys0+azed7LSMKScw==",
       "license": "MIT",
       "dependencies": {
         "boxen": "5.1.2",
@@ -3614,6 +3532,7 @@
     "node_modules/@nestjs/typeorm": {
       "version": "11.0.0",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -3678,6 +3597,7 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3694,9 +3614,8 @@
     },
     "node_modules/@opentelemetry/context-async-hooks": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz",
-      "integrity": "sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -3706,9 +3625,8 @@
     },
     "node_modules/@opentelemetry/core": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
-      "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -3736,8 +3654,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-amqplib": {
       "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.58.0.tgz",
-      "integrity": "sha512-fjpQtH18J6GxzUZ+cwNhWUpb71u+DzT7rFkg5pLssDGaEber91Y2WNGdpVpwGivfEluMlNMZumzjEqfg8DeKXQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
@@ -3753,8 +3669,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-connect": {
       "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.54.0.tgz",
-      "integrity": "sha512-43RmbhUhqt3uuPnc16cX6NsxEASEtn8z/cYV8Zpt6EP4p2h9s4FNuJ4Q9BbEQ2C0YlCCB/2crO1ruVz/hWt8fA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
@@ -3771,8 +3685,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-dataloader": {
       "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.28.0.tgz",
-      "integrity": "sha512-ExXGBp0sUj8yhm6Znhf9jmuOaGDsYfDES3gswZnKr4MCqoBWQdEFn6EoDdt5u+RdbxQER+t43FoUihEfTSqsjA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0"
@@ -3786,8 +3698,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-express": {
       "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.59.0.tgz",
-      "integrity": "sha512-pMKV/qnHiW/Q6pmbKkxt0eIhuNEtvJ7sUAyee192HErlr+a1Jx+FZ3WjfmzhQL1geewyGEiPGkmjjAgNY8TgDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
@@ -3803,8 +3713,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-fs": {
       "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.30.0.tgz",
-      "integrity": "sha512-n3Cf8YhG7reaj5dncGlRIU7iT40bxPOjsBEA5Bc1a1g6e9Qvb+JFJ7SEiMlPbUw4PBmxE3h40ltE8LZ3zVt6OA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
@@ -3819,8 +3727,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-generic-pool": {
       "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.54.0.tgz",
-      "integrity": "sha512-8dXMBzzmEdXfH/wjuRvcJnUFeWzZHUnExkmFJ2uPfa31wmpyBCMxO59yr8f/OXXgSogNgi/uPo9KW9H7LMIZ+g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0"
@@ -3834,8 +3740,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-graphql": {
       "version": "0.58.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.58.0.tgz",
-      "integrity": "sha512-+yWVVY7fxOs3j2RixCbvue8vUuJ1inHxN2q1sduqDB0Wnkr4vOzVKRYl/Zy7B31/dcPS72D9lo/kltdOTBM3bQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0"
@@ -3849,8 +3753,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-hapi": {
       "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.57.0.tgz",
-      "integrity": "sha512-Os4THbvls8cTQTVA8ApLfZZztuuqGEeqog0XUnyRW7QVF0d/vOVBEcBCk1pazPFmllXGEdNbbat8e2fYIWdFbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
@@ -3866,8 +3768,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-http": {
       "version": "0.211.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.211.0.tgz",
-      "integrity": "sha512-n0IaQ6oVll9PP84SjbOCwDjaJasWRHi6BLsbMLiT6tNj7QbVOkuA5sk/EfZczwI0j5uTKl1awQPivO/ldVtsqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "2.5.0",
@@ -3884,8 +3784,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
-      "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -3899,8 +3797,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-ioredis": {
       "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.59.0.tgz",
-      "integrity": "sha512-875UxzBHWkW+P4Y45SoFM2AR8f8TzBMD8eO7QXGCyFSCUMP5s9vtt/BS8b/r2kqLyaRPK6mLbdnZznK3XzQWvw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -3916,8 +3812,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-kafkajs": {
       "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.20.0.tgz",
-      "integrity": "sha512-yJXOuWZROzj7WmYCUiyT27tIfqBrVtl1/TwVbQyWPz7rL0r1Lu7kWjD0PiVeTCIL6CrIZ7M2s8eBxsTAOxbNvw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -3932,8 +3826,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-knex": {
       "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.55.0.tgz",
-      "integrity": "sha512-FtTL5DUx5Ka/8VK6P1VwnlUXPa3nrb7REvm5ddLUIeXXq4tb9pKd+/ThB1xM/IjefkRSN3z8a5t7epYw1JLBJQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -3948,8 +3840,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-koa": {
       "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.59.0.tgz",
-      "integrity": "sha512-K9o2skADV20Skdu5tG2bogPKiSpXh4KxfLjz6FuqIVvDJNibwSdu5UvyyBzRVp1rQMV6UmoIk6d3PyPtJbaGSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
@@ -3965,8 +3855,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
       "version": "0.55.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.55.0.tgz",
-      "integrity": "sha512-FDBfT7yDGcspN0Cxbu/k8A0Pp1Jhv/m7BMTzXGpcb8ENl3tDj/51U65R5lWzUH15GaZA15HQ5A5wtafklxYj7g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0"
@@ -3980,8 +3868,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-mongodb": {
       "version": "0.64.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.64.0.tgz",
-      "integrity": "sha512-pFlCJjweTqVp7B220mCvCld1c1eYKZfQt1p3bxSbcReypKLJTwat+wbL2YZoX9jPi5X2O8tTKFEOahO5ehQGsA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -3996,8 +3882,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-mongoose": {
       "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.57.0.tgz",
-      "integrity": "sha512-MthiekrU/BAJc5JZoZeJmo0OTX6ycJMiP6sMOSRTkvz5BrPMYDqaJos0OgsLPL/HpcgHP7eo5pduETuLguOqcg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
@@ -4013,8 +3897,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-mysql": {
       "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.57.0.tgz",
-      "integrity": "sha512-HFS/+FcZ6Q7piM7Il7CzQ4VHhJvGMJWjx7EgCkP5AnTntSN5rb5Xi3TkYJHBKeR27A0QqPlGaCITi93fUDs++Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -4030,8 +3912,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-mysql2": {
       "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.57.0.tgz",
-      "integrity": "sha512-nHSrYAwF7+aV1E1V9yOOP9TchOodb6fjn4gFvdrdQXiRE7cMuffyLLbCZlZd4wsspBzVwOXX8mpURdRserAhNA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -4061,8 +3941,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-pg": {
       "version": "0.63.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.63.0.tgz",
-      "integrity": "sha512-dKm/ODNN3GgIQVlbD6ZPxwRc3kleLf95hrRWXM+l8wYo+vSeXtEpQPT53afEf6VFWDVzJK55VGn8KMLtSve/cg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
@@ -4081,8 +3959,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-redis": {
       "version": "0.59.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.59.0.tgz",
-      "integrity": "sha512-JKv1KDDYA2chJ1PC3pLP+Q9ISMQk6h5ey+99mB57/ARk0vQPGZTTEb4h4/JlcEpy7AYT8HIGv7X6l+br03Neeg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -4098,8 +3974,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-tedious": {
       "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.30.0.tgz",
-      "integrity": "sha512-bZy9Q8jFdycKQ2pAsyuHYUHNmCxCOGdG6eg1Mn75RvQDccq832sU5OWOBnc12EFUELI6icJkhR7+EQKMBam2GA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.211.0",
@@ -4115,8 +3989,6 @@
     },
     "node_modules/@opentelemetry/instrumentation-undici": {
       "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.21.0.tgz",
-      "integrity": "sha512-gok0LPUOTz2FQ1YJMZzaHcOzDFyT64XJ8M9rNkugk923/p6lDGms/cRW1cqgqp6N6qcd6K6YdVHwPEhnx9BWbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0",
@@ -4132,8 +4004,6 @@
     },
     "node_modules/@opentelemetry/redis-common": {
       "version": "0.38.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz",
-      "integrity": "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==",
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
@@ -4141,9 +4011,8 @@
     },
     "node_modules/@opentelemetry/resources": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
-      "integrity": "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4157,9 +4026,8 @@
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz",
-      "integrity": "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.0",
         "@opentelemetry/resources": "2.6.0",
@@ -4175,14 +4043,13 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.39.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sql-common": {
       "version": "0.41.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
-      "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/core": "^2.0.0"
@@ -4214,8 +4081,6 @@
     },
     "node_modules/@prisma/instrumentation": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.2.0.tgz",
-      "integrity": "sha512-Rh9Z4x5kEj1OdARd7U18AtVrnL6rmLSI0qYShaB4W7Wx5BKbgzndWF+QnuzMb7GLfVdlT5aYCXoPQVYuYtVu0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.207.0"
@@ -4226,8 +4091,6 @@
     },
     "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
       "version": "0.207.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
-      "integrity": "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -4238,8 +4101,6 @@
     },
     "node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
       "version": "0.207.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz",
-      "integrity": "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api-logs": "0.207.0",
@@ -4308,8 +4169,6 @@
     },
     "node_modules/@sentry/core": {
       "version": "10.42.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.42.0.tgz",
-      "integrity": "sha512-L4rMrXMqUKBanpjpMT+TuAVk6xAijz6AWM6RiEYpohAr7SGcCEc1/T0+Ep1eLV8+pwWacfU27OvELIyNeOnGzA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4317,8 +4176,6 @@
     },
     "node_modules/@sentry/nestjs": {
       "version": "10.42.0",
-      "resolved": "https://registry.npmjs.org/@sentry/nestjs/-/nestjs-10.42.0.tgz",
-      "integrity": "sha512-ISfULcCtwo3vrLZUy/lxv5LFDWdUz+qkaPpvTw0t1CyMcrhHMBVshUfxXklbnvGmwSAeXioDT4XyKMZKYViEFA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -4339,8 +4196,6 @@
     },
     "node_modules/@sentry/node": {
       "version": "10.42.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.42.0.tgz",
-      "integrity": "sha512-ZZfU3Fnni7Aj0lTX4e3QpY3UxK4FGuzfM20316UAJycBGnripm+sDHwcekPMGfLnk/FrN9wa1atspVlHvOI0WQ==",
       "license": "MIT",
       "dependencies": {
         "@fastify/otel": "0.16.0",
@@ -4385,8 +4240,6 @@
     },
     "node_modules/@sentry/node-core": {
       "version": "10.42.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.42.0.tgz",
-      "integrity": "sha512-9tf3fPV6M071aps72D+PEtdQPTuj+SuqO2+PpTfdPP5ZL4TTKYo3VK0li76SL+5wGdTFGV5qmsokHq9IRBA0iA==",
       "license": "MIT",
       "dependencies": {
         "@sentry/core": "10.42.0",
@@ -4431,8 +4284,6 @@
     },
     "node_modules/@sentry/opentelemetry": {
       "version": "10.42.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.42.0.tgz",
-      "integrity": "sha512-5vsYz683iihzlIj3sT1+tEixf0awwXK86a+aYsnMHrTXJDrkBDq4U0ZT+yxdPfJlkaxRtYycFR08SXr2pSm7Eg==",
       "license": "MIT",
       "dependencies": {
         "@sentry/core": "10.42.0"
@@ -4482,8 +4333,6 @@
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.11.tgz",
-      "integrity": "sha512-Hj4WoYWMJnSpM6/kchsm4bUNTL9XiSyhvoMb2KIq4VJzyDt7JpGHUZHkVNPZVC7YE1tf8tPeVauxpFBKGW4/KQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -4520,8 +4369,6 @@
     },
     "node_modules/@smithy/config-resolver": {
       "version": "4.4.10",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.10.tgz",
-      "integrity": "sha512-IRTkd6ps0ru+lTWnfnsbXzW80A8Od8p3pYiZnW98K2Hb20rqfsX7VTlfUwhrcOeSSy68Gn9WBofwPuw3e5CCsg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.11",
@@ -4537,8 +4384,6 @@
     },
     "node_modules/@smithy/core": {
       "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.8.tgz",
-      "integrity": "sha512-f7uPeBi7ehmLT4YF2u9j3qx6lSnurG1DLXOsTtJrIRNDF7VXio4BGHQ+SQteN/BrUVudbkuL4v7oOsRCzq4BqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/middleware-serde": "^4.2.12",
@@ -4558,8 +4403,6 @@
     },
     "node_modules/@smithy/credential-provider-imds": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.11.tgz",
-      "integrity": "sha512-lBXrS6ku0kTj3xLmsJW0WwqWbGQ6ueooYyp/1L9lkyT0M02C+DWwYwc5aTyXFbRaK38ojALxNixg+LxKSHZc0g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.11",
@@ -4644,8 +4487,6 @@
     },
     "node_modules/@smithy/fetch-http-handler": {
       "version": "5.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.13.tgz",
-      "integrity": "sha512-U2Hcfl2s3XaYjikN9cT4mPu8ybDbImV3baXR0PkVlC0TTx808bRP3FaPGAzPtB8OByI+JqJ1kyS+7GEgae7+qQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.11",
@@ -4717,8 +4558,6 @@
     },
     "node_modules/@smithy/is-array-buffer": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
-      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4757,8 +4596,6 @@
     },
     "node_modules/@smithy/middleware-endpoint": {
       "version": "4.4.22",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.22.tgz",
-      "integrity": "sha512-sc81w1o4Jy+/MAQlY3sQ8C7CmSpcvIi3TAzXblUv2hjG11BBSJi/Cw8vDx5BxMxapuH2I+Gc+45vWsgU07WZRQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.23.8",
@@ -4776,8 +4613,6 @@
     },
     "node_modules/@smithy/middleware-retry": {
       "version": "4.4.39",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.39.tgz",
-      "integrity": "sha512-MCVCxaCzuZgiHtHGV2Ke44nh6t4+8/tO+rTYOzrr2+G4nMLU/qbzNCWKBX54lyEaVcGQrfOJiG2f8imtiw+nIQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.11",
@@ -4796,8 +4631,6 @@
     },
     "node_modules/@smithy/middleware-serde": {
       "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.12.tgz",
-      "integrity": "sha512-W9g1bOLui7Xn5FABRVS0o3rXL0gfN37d/8I/W7i0N7oxjx9QecUmXEMSUMADTODwdtka9cN43t5BI2CodLJpng==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.11",
@@ -4810,8 +4643,6 @@
     },
     "node_modules/@smithy/middleware-stack": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.11.tgz",
-      "integrity": "sha512-s+eenEPW6RgliDk2IhjD2hWOxIx1NKrOHxEwNUaUXxYBxIyCcDfNULZ2Mu15E3kwcJWBedTET/kEASPV1A1Akg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -4823,8 +4654,6 @@
     },
     "node_modules/@smithy/node-config-provider": {
       "version": "4.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.11.tgz",
-      "integrity": "sha512-xD17eE7kaLgBBGf5CZQ58hh2YmwK1Z0O8YhffwB/De2jsL0U3JklmhVYJ9Uf37OtUDLF2gsW40Xwwag9U869Gg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.11",
@@ -4838,8 +4667,6 @@
     },
     "node_modules/@smithy/node-http-handler": {
       "version": "4.4.14",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.14.tgz",
-      "integrity": "sha512-DamSqaU8nuk0xTJDrYnRzZndHwwRnyj/n/+RqGGCcBKB4qrQem0mSDiWdupaNWdwxzyMU91qxDmHOCazfhtO3A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^4.2.11",
@@ -4854,8 +4681,6 @@
     },
     "node_modules/@smithy/property-provider": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.11.tgz",
-      "integrity": "sha512-14T1V64o6/ndyrnl1ze1ZhyLzIeYNN47oF/QU6P5m82AEtyOkMJTb0gO1dPubYjyyKuPD6OSVMPDKe+zioOnCg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -4867,8 +4692,6 @@
     },
     "node_modules/@smithy/protocol-http": {
       "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.11.tgz",
-      "integrity": "sha512-hI+barOVDJBkNt4y0L2mu3Ugc0w7+BpJ2CZuLwXtSltGAAwCb3IvnalGlbDV/UCS6a9ZuT3+exd1WxNdLb5IlQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -4880,8 +4703,6 @@
     },
     "node_modules/@smithy/querystring-builder": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.11.tgz",
-      "integrity": "sha512-7spdikrYiljpket6u0up2Ck2mxhy7dZ0+TDd+S53Dg2DHd6wg+YNJrTCHiLdgZmEXZKI7LJZcwL3721ZRDFiqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -4894,8 +4715,6 @@
     },
     "node_modules/@smithy/querystring-parser": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.11.tgz",
-      "integrity": "sha512-nE3IRNjDltvGcoThD2abTozI1dkSy8aX+a2N1Rs55en5UsdyyIXgGEmevUL3okZFoJC77JgRGe99xYohhsjivQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -4907,8 +4726,6 @@
     },
     "node_modules/@smithy/service-error-classification": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.11.tgz",
-      "integrity": "sha512-HkMFJZJUhzU3HvND1+Yw/kYWXp4RPDLBWLcK1n+Vqw8xn4y2YiBhdww8IxhkQjP/QlZun5bwm3vcHc8AqIU3zw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0"
@@ -4919,8 +4736,6 @@
     },
     "node_modules/@smithy/shared-ini-file-loader": {
       "version": "4.4.6",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.6.tgz",
-      "integrity": "sha512-IB/M5I8G0EeXZTHsAxpx51tMQ5R719F3aq+fjEB6VtNcCHDc0ajFDIGDZw+FW9GxtEkgTduiPpjveJdA/CX7sw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -4951,8 +4766,6 @@
     },
     "node_modules/@smithy/smithy-client": {
       "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.2.tgz",
-      "integrity": "sha512-HezY3UuG0k4T+4xhFKctLXCA5N2oN+Rtv+mmL8Gt7YmsUY2yhmcLyW75qrSzldfj75IsCW/4UhY3s20KcFnZqA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.23.8",
@@ -4969,8 +4782,6 @@
     },
     "node_modules/@smithy/types": {
       "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
-      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4981,8 +4792,6 @@
     },
     "node_modules/@smithy/url-parser": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.11.tgz",
-      "integrity": "sha512-oTAGGHo8ZYc5VZsBREzuf5lf2pAurJQsccMusVZ85wDkX66ojEc/XauiGjzCj50A61ObFTPe6d7Pyt6UBYaing==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/querystring-parser": "^4.2.11",
@@ -4995,8 +4804,6 @@
     },
     "node_modules/@smithy/util-base64": {
       "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.2",
@@ -5009,8 +4816,6 @@
     },
     "node_modules/@smithy/util-body-length-browser": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
-      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5033,8 +4838,6 @@
     },
     "node_modules/@smithy/util-buffer-from": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
-      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
@@ -5046,8 +4849,6 @@
     },
     "node_modules/@smithy/util-config-provider": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
-      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5058,8 +4859,6 @@
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
       "version": "4.3.38",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.38.tgz",
-      "integrity": "sha512-c8P1mFLNxcsdAMabB8/VUQUbWzFmgujWi4bAXSggcqLYPc8V4U5abqFqOyn+dK4YT+q8UyCVkTO8807t4t2syA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.11",
@@ -5073,8 +4872,6 @@
     },
     "node_modules/@smithy/util-defaults-mode-node": {
       "version": "4.2.41",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.41.tgz",
-      "integrity": "sha512-/UG+9MT3UZAR0fLzOtMJMfWGcjjHvgggq924x/CRy8vRbL+yFf3Z6vETlvq8vDH92+31P/1gSOFoo7303wN8WQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.4.10",
@@ -5091,8 +4888,6 @@
     },
     "node_modules/@smithy/util-endpoints": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.2.tgz",
-      "integrity": "sha512-+4HFLpE5u29AbFlTdlKIT7jfOzZ8PDYZKTb3e+AgLz986OYwqTourQ5H+jg79/66DB69Un1+qKecLnkZdAsYcA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.11",
@@ -5105,8 +4900,6 @@
     },
     "node_modules/@smithy/util-hex-encoding": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
-      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5117,8 +4910,6 @@
     },
     "node_modules/@smithy/util-middleware": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.11.tgz",
-      "integrity": "sha512-r3dtF9F+TpSZUxpOVVtPfk09Rlo4lT6ORBqEvX3IBT6SkQAdDSVKR5GcfmZbtl7WKhKnmb3wbDTQ6ibR2XHClw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -5130,8 +4921,6 @@
     },
     "node_modules/@smithy/util-retry": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.11.tgz",
-      "integrity": "sha512-XSZULmL5x6aCTTii59wJqKsY1l3eMIAomRAccW7Tzh9r8s7T/7rdo03oektuH5jeYRlJMPcNP92EuRDvk9aXbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/service-error-classification": "^4.2.11",
@@ -5144,8 +4933,6 @@
     },
     "node_modules/@smithy/util-stream": {
       "version": "4.5.17",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.17.tgz",
-      "integrity": "sha512-793BYZ4h2JAQkNHcEnyFxDTcZbm9bVybD0UV/LEWmZ5bkTms7JqjfrLMi2Qy0E5WFcCzLwCAPgcvcvxoeALbAQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.13",
@@ -5163,8 +4950,6 @@
     },
     "node_modules/@smithy/util-uri-escape": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5175,8 +4960,6 @@
     },
     "node_modules/@smithy/util-utf8": {
       "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.2",
@@ -5202,8 +4985,6 @@
     },
     "node_modules/@smithy/uuid": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
-      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -5218,8 +4999,6 @@
     },
     "node_modules/@stryker-mutator/api": {
       "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/api/-/api-9.6.0.tgz",
-      "integrity": "sha512-kJEEwOVoWDXGEIXuM+9efT6LSJ7nyxnQQvjEoKg8GSZXbDUjfD0tqA0aBD06U1SzQLKCM7ffjgPffr154MHZKw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5234,10 +5013,9 @@
     },
     "node_modules/@stryker-mutator/core": {
       "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/core/-/core-9.6.0.tgz",
-      "integrity": "sha512-oSbw01l6HXHt0iW9x5fQj7yHGGT8ZjCkXSkI7Bsu0juO7Q6vRMXk7XcvKpCBgRgzKXi1osg8+iIzj7acHuxepQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@inquirer/prompts": "^8.0.0",
         "@stryker-mutator/api": "9.6.0",
@@ -5783,8 +5561,6 @@
     },
     "node_modules/@stryker-mutator/instrumenter": {
       "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/instrumenter/-/instrumenter-9.6.0.tgz",
-      "integrity": "sha512-tWdRYfm9LF4Go7cNOos0xEIOEnN7ZOSj38rfXvGZS9IINlvYBrBCl2xcz/67v6l5A7xksMWWByZRIq2bgdnnUg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5807,8 +5583,6 @@
     },
     "node_modules/@stryker-mutator/jest-runner": {
       "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/jest-runner/-/jest-runner-9.6.0.tgz",
-      "integrity": "sha512-o98fwUe9VSXkHaiixAm3FJzQjUFAtZSkh6eWya79nCbqOV9mYQCMUmCN0apEVQZzKyW35FGVgjCohuFUQ9n+gQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5826,8 +5600,6 @@
     },
     "node_modules/@stryker-mutator/typescript-checker": {
       "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/typescript-checker/-/typescript-checker-9.6.0.tgz",
-      "integrity": "sha512-mPoB2Eogda4bpIoNgdN+VHnZvbwD0R/oNCCbmq7UQVLZtzF09nH1M1kbilYdmrCyxYYkFyTCKy3WhU3YGWdDjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5845,8 +5617,6 @@
     },
     "node_modules/@stryker-mutator/util": {
       "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@stryker-mutator/util/-/util-9.6.0.tgz",
-      "integrity": "sha512-gw7fJOFNHEj9inAEOodD9RrrMEMhZmWJ46Ww/kDJAXlSsBBmdwCzeomNLngmLTvgp14z7Tfq85DHYwvmNMdOxA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -5871,29 +5641,21 @@
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
-      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -5964,8 +5726,6 @@
     },
     "node_modules/@types/cloudmersive-virus-api-client": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@types/cloudmersive-virus-api-client/-/cloudmersive-virus-api-client-1.1.4.tgz",
-      "integrity": "sha512-G8BnUCii4Gf5VZiAVr0QrpXxC1PkvcC4xe8I7IbcdlUqpHsyxhGFRucABMPkMw7+/WmnMEsIqyMnUqlSZwIeqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5986,8 +5746,6 @@
     },
     "node_modules/@types/ejs": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.5.tgz",
-      "integrity": "sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -5995,6 +5753,7 @@
       "version": "9.6.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -6011,8 +5770,6 @@
     },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
-      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6044,8 +5801,6 @@
     },
     "node_modules/@types/html-to-text": {
       "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/@types/html-to-text/-/html-to-text-9.0.4.tgz",
-      "integrity": "sha512-pUY3cKH/Nm2yYrEmDlPR1mR7yszjGx4DrwPjQ702C4/D5CwHuZTgZdIdwPkRbcuhs7BAh2L5rg3CL5cbRiGTCQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -6108,8 +5863,6 @@
     },
     "node_modules/@types/mjml": {
       "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/@types/mjml/-/mjml-4.7.4.tgz",
-      "integrity": "sha512-vyi1vzWgMzFMwZY7GSZYX0GU0dmtC8vLHwpgk+NWmwbwRSrlieVyJ9sn5elodwUfklJM7yGl0zQeet1brKTWaQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6118,8 +5871,6 @@
     },
     "node_modules/@types/mjml-core": {
       "version": "4.15.2",
-      "resolved": "https://registry.npmjs.org/@types/mjml-core/-/mjml-core-4.15.2.tgz",
-      "integrity": "sha512-Q7SxFXgoX979HP57DEVsRI50TV8x1V4lfCA4Up9AvfINDM5oD/X9ARgfoyX1qS987JCnDLv85JjkqAjt3hZSiQ==",
       "license": "MIT",
       "optional": true
     },
@@ -6139,8 +5890,6 @@
     },
     "node_modules/@types/mysql": {
       "version": "2.15.27",
-      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
-      "integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -6151,14 +5900,13 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/passport": {
       "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
-      "integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6167,8 +5915,6 @@
     },
     "node_modules/@types/passport-jwt": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/passport-jwt/-/passport-jwt-4.0.1.tgz",
-      "integrity": "sha512-Y0Ykz6nWP4jpxgEUYq8NoVZeCQPo1ZndJLfapI249g1jHChvRfZRO/LS3tqu26YgAS/laI1qx98sYGz0IalRXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6178,8 +5924,6 @@
     },
     "node_modules/@types/passport-local": {
       "version": "1.0.38",
-      "resolved": "https://registry.npmjs.org/@types/passport-local/-/passport-local-1.0.38.tgz",
-      "integrity": "sha512-nsrW4A963lYE7lNTv9cr5WmiUD1ibYJvWrpE13oxApFsRt77b0RdtZvKbCdNIY4v/QZ6TRQWaDDEwV1kCTmcXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6190,8 +5934,6 @@
     },
     "node_modules/@types/passport-strategy": {
       "version": "0.2.38",
-      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
-      "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6201,8 +5943,6 @@
     },
     "node_modules/@types/pg": {
       "version": "8.15.6",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
-      "integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -6212,8 +5952,6 @@
     },
     "node_modules/@types/pg-pool": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.7.tgz",
-      "integrity": "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==",
       "license": "MIT",
       "dependencies": {
         "@types/pg": "*"
@@ -6221,8 +5959,6 @@
     },
     "node_modules/@types/pug": {
       "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.10.tgz",
-      "integrity": "sha512-Sk/uYFOBAB7mb74XcpizmH0KOR2Pv3D2Hmrh1Dmy5BmK3MpdSa5kqZcg6EKBdklU0bFXX9gCfzvpnyUehrPIuA==",
       "license": "MIT",
       "optional": true
     },
@@ -6238,8 +5974,6 @@
     },
     "node_modules/@types/relateurl": {
       "version": "0.2.33",
-      "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.33.tgz",
-      "integrity": "sha512-bTQCKsVbIdzLqZhLkF5fcJQreE4y1ro4DIyVrlDNSCJRRwHhB8Z+4zXXa8jN6eDvc2HbRsEYgbvrnGvi54EpSw==",
       "license": "MIT",
       "optional": true
     },
@@ -6278,8 +6012,6 @@
     },
     "node_modules/@types/supertest": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
-      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6289,8 +6021,6 @@
     },
     "node_modules/@types/tedious": {
       "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
-      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -6319,8 +6049,6 @@
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
-      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6348,10 +6076,9 @@
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
-      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -6373,8 +6100,6 @@
     },
     "node_modules/@typescript-eslint/project-service": {
       "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
-      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6395,8 +6120,6 @@
     },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
-      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6413,8 +6136,6 @@
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
-      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6430,8 +6151,6 @@
     },
     "node_modules/@typescript-eslint/type-utils": {
       "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
-      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6455,8 +6174,6 @@
     },
     "node_modules/@typescript-eslint/types": {
       "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
-      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6469,8 +6186,6 @@
     },
     "node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
-      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6497,8 +6212,6 @@
     },
     "node_modules/@typescript-eslint/utils": {
       "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
-      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6521,8 +6234,6 @@
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
-      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6539,8 +6250,6 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -6965,8 +6674,6 @@
     },
     "node_modules/@zone-eu/mailsplit": {
       "version": "5.4.8",
-      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.8.tgz",
-      "integrity": "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA==",
       "license": "(MIT OR EUPL-1.1+)",
       "optional": true,
       "dependencies": {
@@ -6988,9 +6695,8 @@
     },
     "node_modules/acorn": {
       "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7018,8 +6724,6 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -7028,8 +6732,6 @@
     },
     "node_modules/acorn-walk": {
       "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -7041,10 +6743,9 @@
     },
     "node_modules/ajv": {
       "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7085,8 +6786,6 @@
     },
     "node_modules/alce": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/alce/-/alce-1.2.0.tgz",
-      "integrity": "sha512-XppPf2S42nO2WhvKzlwzlfcApcXHzjlod30pKmcWjRgLOtqoe5DMuqdiYoM6AgyXksc6A6pV4v1L/WW217e57w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7099,8 +6798,6 @@
     },
     "node_modules/alce/node_modules/esprima": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
-      "integrity": "sha512-S9VbPDU0adFErpDai3qDkjq8+G05ONtKzcyNrPKg/ZKa+tf879nX2KexNU95b31UoTJjRLInNBHHHjFPoCd7lQ==",
       "optional": true,
       "bin": {
         "esparse": "bin/esparse.js",
@@ -7112,8 +6809,6 @@
     },
     "node_modules/alce/node_modules/estraverse": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-      "integrity": "sha512-25w1fMXQrGdoquWnScXZGckOv+Wes+JDnuN/+7ex3SauFRS72r2lFDec0EKPt2YD1wUJ/IrfEex+9yp4hfSOJA==",
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
@@ -7121,8 +6816,6 @@
     },
     "node_modules/angular-html-parser": {
       "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-10.4.0.tgz",
-      "integrity": "sha512-++nLNyZwRfHqFh7akH5Gw/JYizoFlMRz0KRigfwfsLqV8ZqlcVRb1LkPEWdYvEKDnbktknM2J4BXaYUGrQZPww==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7221,8 +6914,6 @@
     },
     "node_modules/arg": {
       "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -7241,8 +6932,6 @@
     },
     "node_modules/assert-never": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/assert-never/-/assert-never-1.4.0.tgz",
-      "integrity": "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA==",
       "license": "MIT",
       "optional": true
     },
@@ -7368,8 +7057,6 @@
     },
     "node_modules/babel-walk": {
       "version": "3.0.0-canary-5",
-      "resolved": "https://registry.npmjs.org/babel-walk/-/babel-walk-3.0.0-canary-5.tgz",
-      "integrity": "sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7381,8 +7068,6 @@
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -7428,8 +7113,6 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -7492,13 +7175,13 @@
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "devOptional": true,
       "license": "ISC"
     },
     "node_modules/bowser": {
-      "version": "2.13.1",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
     },
     "node_modules/boxen": {
@@ -7558,8 +7241,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -7596,6 +7277,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7735,8 +7417,6 @@
     },
     "node_modules/caniuse-api": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
-      "integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -7789,8 +7469,6 @@
     },
     "node_modules/character-parser": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-2.2.0.tgz",
-      "integrity": "sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7811,8 +7489,6 @@
     },
     "node_modules/cheerio": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
-      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7837,8 +7513,6 @@
     },
     "node_modules/cheerio-select": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
       "license": "BSD-2-Clause",
       "optional": true,
       "dependencies": {
@@ -7855,8 +7529,6 @@
     },
     "node_modules/cheerio/node_modules/htmlparser2": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
-      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -7877,6 +7549,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -7915,13 +7588,13 @@
     },
     "node_modules/class-transformer": {
       "version": "0.5.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.15.1.tgz",
-      "integrity": "sha512-LqoS80HBBSCVhz/3KloUly0ovokxpdOLR++Al3J3+dHXWt9sTKlKd4eYtoxhxyUjoe5+UcIM+5k9MIxyBWnRTw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -8079,8 +7752,6 @@
     },
     "node_modules/colord": {
       "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -8144,8 +7815,6 @@
     },
     "node_modules/constantinople": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-4.0.1.tgz",
-      "integrity": "sha512-vCrqcSIq4//Gx74TXXCGnHpulY1dskqLTFGDmhrGxzeXL8lF8kvXv6mpNWlJj1uD4DW23D4ljAqbY4RRaaUZIw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8241,8 +7910,6 @@
     },
     "node_modules/create-require": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -8294,8 +7961,6 @@
     },
     "node_modules/css-declaration-sorter": {
       "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.1.tgz",
-      "integrity": "sha512-gz6x+KkgNCjxq3Var03pRYLhyNfwhkKF1g/yoLgDNtFvVu0/fOLV9C8fFEZRjACp/XQLumjAYo7JVjzH3wLbxA==",
       "devOptional": true,
       "license": "ISC",
       "engines": {
@@ -8307,8 +7972,6 @@
     },
     "node_modules/css-select": {
       "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -8324,8 +7987,6 @@
     },
     "node_modules/css-tree": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.0.tgz",
-      "integrity": "sha512-t99A4LolkP0ZX9WUoaHz4YrPT1FKNlV8IDCeCPPpGaWyxegh64tt/BSUqN3u5necrYRon+ddZ6mPMjxIlfpobg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -8338,8 +7999,6 @@
     },
     "node_modules/css-what": {
       "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
       "devOptional": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -8351,8 +8010,6 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "devOptional": true,
       "license": "MIT",
       "bin": {
@@ -8364,10 +8021,9 @@
     },
     "node_modules/cssnano": {
       "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-7.1.2.tgz",
-      "integrity": "sha512-HYOPBsNvoiFeR1eghKD5C3ASm64v9YVyJB4Ivnl2gqKoQYvjjN/G0rztvKQq8OxocUtC6sjqY8jwYngIB4AByA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssnano-preset-default": "^7.0.10",
         "lilconfig": "^3.1.3"
@@ -8385,8 +8041,6 @@
     },
     "node_modules/cssnano-preset-default": {
       "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-7.0.10.tgz",
-      "integrity": "sha512-6ZBjW0Lf1K1Z+0OKUAUpEN62tSXmYChXWi2NAA0afxEVsj9a+MbcB1l5qel6BHJHmULai2fCGRthCeKSFbScpA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -8430,8 +8084,6 @@
     },
     "node_modules/cssnano-preset-lite": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/cssnano-preset-lite/-/cssnano-preset-lite-4.0.4.tgz",
-      "integrity": "sha512-iV7xT9JEk0OJwRWuSV2Y48IkntNjvoiscoioFDcgmuoIvpZV8gIg1++GBHTj72HgmDCALH8y9ELgt+aFM2Nh9g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8449,8 +8101,6 @@
     },
     "node_modules/cssnano-utils": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-5.0.1.tgz",
-      "integrity": "sha512-ZIP71eQgG9JwjVZsTPSqhc6GHgEr53uJ7tK5///VfyWj6Xp2DBmixWHqJgPno+PqATzn48pL42ww9x5SSGmhZg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -8462,8 +8112,6 @@
     },
     "node_modules/csso": {
       "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -8476,8 +8124,6 @@
     },
     "node_modules/csso/node_modules/css-tree": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -8491,8 +8137,6 @@
     },
     "node_modules/csso/node_modules/mdn-data": {
       "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "devOptional": true,
       "license": "CC0-1.0"
     },
@@ -8529,8 +8173,6 @@
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8607,8 +8249,6 @@
     },
     "node_modules/detect-indent": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
-      "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8625,8 +8265,6 @@
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "license": "MIT",
       "optional": true
     },
@@ -8645,8 +8283,6 @@
     },
     "node_modules/display-notification": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/display-notification/-/display-notification-2.0.0.tgz",
-      "integrity": "sha512-TdmtlAcdqy1NU+j7zlkDdMnCL878zriLaBmoD9quOoq1ySSSGv03l0hXK5CvIFZlIfFI/hizqdQuW+Num7xuhw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8659,8 +8295,6 @@
     },
     "node_modules/doctypes": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/doctypes/-/doctypes-1.1.0.tgz",
-      "integrity": "sha512-LLBi6pEqS6Do3EKQ3J0NqHWV5hhb78Pi8vvESYwyOy2c31ZEZVdtitdzsQsKb7878PEERhzUk0ftqGhG6Mz+pQ==",
       "license": "MIT",
       "optional": true
     },
@@ -8713,8 +8347,6 @@
     },
     "node_modules/dotenv": {
       "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -8810,8 +8442,6 @@
     },
     "node_modules/encoding-japanese": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
-      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8820,8 +8450,6 @@
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
-      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8834,8 +8462,6 @@
     },
     "node_modules/encoding-sniffer/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8869,8 +8495,6 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8936,8 +8560,6 @@
     },
     "node_modules/escape-goat": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-3.0.0.tgz",
-      "integrity": "sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8953,8 +8575,6 @@
     },
     "node_modules/escape-string-applescript": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-applescript/-/escape-string-applescript-1.0.0.tgz",
-      "integrity": "sha512-4/hFwoYaC6TkpDn9A3pTC52zQPArFeXuIfhUtCGYdauTzXVP9H3BDr3oO/QzQehMpLDC7srvYgfwvImPFGfvBA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8974,10 +8594,9 @@
     },
     "node_modules/eslint": {
       "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
-      "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9032,6 +8651,7 @@
       "version": "10.1.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9081,8 +8701,6 @@
     },
     "node_modules/eslint-scope": {
       "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.1.tgz",
-      "integrity": "sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -9111,8 +8729,6 @@
     },
     "node_modules/eslint/node_modules/ajv": {
       "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9128,8 +8744,6 @@
     },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -9149,15 +8763,11 @@
     },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/espree": {
       "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.1.tgz",
-      "integrity": "sha512-AVHPqQoZYc+RUM4/3Ly5udlZY/U4LS8pIG05jEjWM2lQMU/oaZ7qshzAl2YP1tfNmXfftH3ohurfwNAug+MnsQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -9174,8 +8784,6 @@
     },
     "node_modules/espree/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -9304,6 +8912,7 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9347,6 +8956,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
       "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "10.1.0"
       },
@@ -9381,15 +8991,11 @@
     },
     "node_modules/extend-object": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/extend-object/-/extend-object-1.0.0.tgz",
-      "integrity": "sha512-0dHDIXC7y7LDmCh/lp1oYkmv73K25AMugQI07r8eFopkW6f7Ufn1q+ETMsJjnV9Am14SlElkqy3O92r6xEaxPw==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/fast-check": {
       "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.5.3.tgz",
-      "integrity": "sha512-IE9csY7lnhxBnA8g/WI5eg/hygA6MGWJMSNfFRrBlXUciADEhS1EDB0SIsMSvzubzIlOBbVITSsypCsW717poA==",
       "dev": true,
       "funding": [
         {
@@ -9520,8 +9126,6 @@
     },
     "node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9642,8 +9246,6 @@
     },
     "node_modules/fixpack": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fixpack/-/fixpack-4.0.0.tgz",
-      "integrity": "sha512-5SM1+H2CcuJ3gGEwTiVo/+nd/hYpNj9Ch3iMDOQ58ndY+VGQ2QdvaUTkd3otjZvYnd/8LF/HkJ5cx7PBq0orCQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9660,8 +9262,6 @@
     },
     "node_modules/fixpack/node_modules/chalk": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9801,8 +9401,6 @@
     },
     "node_modules/forwarded-parse": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
-      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
       "license": "MIT"
     },
     "node_modules/fresh": {
@@ -9909,8 +9507,6 @@
     },
     "node_modules/get-port": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/get-port/-/get-port-5.1.1.tgz",
-      "integrity": "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -9944,8 +9540,6 @@
     },
     "node_modules/glob": {
       "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.2.2",
@@ -9977,8 +9571,6 @@
     },
     "node_modules/globals": {
       "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10083,8 +9675,6 @@
     },
     "node_modules/he": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -10119,8 +9709,6 @@
     },
     "node_modules/htmlnano": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.1.5.tgz",
-      "integrity": "sha512-IXffzXq1beGQN2rsr03aIPK/rVU1jR2uwHymlAIEf97Tl5WdpG50IsQ5nWGvSGQJ+x6U7S6yac9rRiFgAg4/xQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10167,8 +9755,6 @@
     },
     "node_modules/htmlnano/node_modules/cosmiconfig": {
       "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10237,8 +9823,6 @@
     },
     "node_modules/husky": {
       "version": "9.1.7",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
-      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -10253,8 +9837,6 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -10350,16 +9932,13 @@
     },
     "node_modules/ini": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC",
       "optional": true
     },
     "node_modules/ioredis": {
       "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.0.tgz",
-      "integrity": "sha512-HVBe9OFuqs+Z6n64q09PQvP1/R4Bm+30PAyyD4wIEqssh3v9L21QjCVk4kRLucMBcDokJTcLjsGeVRlq/nH6DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -10402,8 +9981,6 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10425,8 +10002,6 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10441,8 +10016,6 @@
     },
     "node_modules/is-docker": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -10457,8 +10030,6 @@
     },
     "node_modules/is-expression": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
-      "integrity": "sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10468,8 +10039,6 @@
     },
     "node_modules/is-expression/node_modules/acorn": {
       "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -10521,8 +10090,6 @@
     },
     "node_modules/is-json": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
-      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
       "license": "ISC",
       "optional": true
     },
@@ -10550,8 +10117,6 @@
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10604,8 +10169,6 @@
     },
     "node_modules/is-wsl": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10711,6 +10274,7 @@
       "version": "30.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -10938,8 +10502,6 @@
     },
     "node_modules/jest-junit": {
       "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-16.0.0.tgz",
-      "integrity": "sha512-A94mmw6NfJab4Fg/BlvVOUXzXgF0XIH6EmTgJ5NDPp4xoKq0Kr7sErb+4Xs9nZvu58pJojz5RFGpqnZYJTrRfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -10954,8 +10516,6 @@
     },
     "node_modules/jest-junit/node_modules/mkdirp": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -11286,8 +10846,6 @@
     },
     "node_modules/js-stringify": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
-      "integrity": "sha512-rtS5ATOo2Q5k1G+DADISilDA6lv79zIiwFd6CcjuIxGKLFm5C+RLImRscVap9k55i+MOZwgliw+NejvkLuGD5g==",
       "license": "MIT",
       "optional": true
     },
@@ -11391,8 +10949,6 @@
     },
     "node_modules/jstransformer": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/jstransformer/-/jstransformer-1.0.0.tgz",
-      "integrity": "sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11402,15 +10958,11 @@
     },
     "node_modules/jstransformer/node_modules/is-promise": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/juice": {
       "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/juice/-/juice-11.1.1.tgz",
-      "integrity": "sha512-4SBfZqKcc6DrIS+5b/WiGoWaZsdUPBH+e6SbRlNjJpaIRtfoBhYReAtobIEW6mcLeFFDXLBJMuZwkJLkBJjs2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11430,8 +10982,6 @@
     },
     "node_modules/juice/node_modules/commander": {
       "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -11440,8 +10990,6 @@
     },
     "node_modules/juice/node_modules/entities": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
-      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "optional": true,
       "engines": {
@@ -11505,15 +11053,11 @@
     },
     "node_modules/libbase64": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-1.3.0.tgz",
-      "integrity": "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/libmime": {
       "version": "5.3.7",
-      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.7.tgz",
-      "integrity": "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11525,8 +11069,6 @@
     },
     "node_modules/libmime/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11542,15 +11084,11 @@
     },
     "node_modules/libqp": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/libqp/-/libqp-2.1.1.tgz",
-      "integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -11567,8 +11105,6 @@
     },
     "node_modules/linkify-it": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11577,8 +11113,6 @@
     },
     "node_modules/liquidjs": {
       "version": "10.24.0",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.24.0.tgz",
-      "integrity": "sha512-TAUNAdgwaAXjjcUFuYVJm9kOVH7zc0mTKxsG9t9Lu4qdWjB2BEblyVIYpjWcmJLMGgiYqnGNJjpNMHx0gp/46A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11598,8 +11132,6 @@
     },
     "node_modules/liquidjs/node_modules/commander": {
       "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -11701,8 +11233,6 @@
     },
     "node_modules/lodash.uniq": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -11723,8 +11253,6 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -11748,8 +11276,6 @@
     },
     "node_modules/mailparser": {
       "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.3.tgz",
-      "integrity": "sha512-AnB0a3zROum6fLaa52L+/K2SoRJVyFDk78Ea6q1D0ofcZLxWEWDtsS1+OrVqKbV7r5dulKL/AwYQccFGAPpuYQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11767,8 +11293,6 @@
     },
     "node_modules/mailparser/node_modules/nodemailer": {
       "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
-      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
       "license": "MIT-0",
       "optional": true,
       "engines": {
@@ -11811,8 +11335,6 @@
     },
     "node_modules/mdn-data": {
       "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "devOptional": true,
       "license": "CC0-1.0"
     },
@@ -11836,8 +11358,6 @@
     },
     "node_modules/mensch": {
       "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/mensch/-/mensch-0.3.4.tgz",
-      "integrity": "sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g==",
       "license": "MIT",
       "optional": true
     },
@@ -11937,8 +11457,6 @@
     },
     "node_modules/minimatch": {
       "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -11960,8 +11478,6 @@
     },
     "node_modules/minipass": {
       "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -11969,8 +11485,6 @@
     },
     "node_modules/mjml": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml/-/mjml-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-ZZS2NaiK24+Wx1aIB5b1t7oKtYuTjsgqCxDaVPsWWHBIRKpTaLVxbcJQXjDyKOGz7PTWUgDY0OEj1O1wtL/jYQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11986,8 +11500,6 @@
     },
     "node_modules/mjml-accordion": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-accordion/-/mjml-accordion-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-ZWzJiClvYvIwR00GaylcMM9GvMaR8qa/tkbCGgwDQBni8aO5H1bl+MvtbC4g7xuWQAlPXJnC8ExZVuze28n29A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11998,8 +11510,6 @@
     },
     "node_modules/mjml-body": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-body/-/mjml-body-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-c2G4HOg1wFmTm1oktL9ny2oWaLV9PtsqeJt9SFw7YSqkU2lRKGvuvgPfQFEOB4F4fNw5ITQqE0AMQlrIclUL4w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12010,8 +11520,6 @@
     },
     "node_modules/mjml-button": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-button/-/mjml-button-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-caaT8Slt4V2Z8e7WaN9a50Xy7ewhx0IBSgFkFw1N/AzrOSgg2unKxSeAEuL7cigK6OtExSMxz0xsgY7+H3lwHA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12022,8 +11530,6 @@
     },
     "node_modules/mjml-carousel": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-carousel/-/mjml-carousel-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-PY/AJfATRgVJbS+buOEFH25tJ18ooXfHI/kDmqEclU8TlYLIqLXvE/BJjkblXtomtNzBhVWWGeu7d7AXbqNVnw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12034,8 +11540,6 @@
     },
     "node_modules/mjml-cli": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-cli/-/mjml-cli-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-18juF8daEX222zSvsYmHoedKdLlKRMIdVRBGwJ/vRbChkP5aHywkonzG+1cfmZWnYTSrZh/liTjXFgrYdNBkfQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12056,8 +11560,6 @@
     },
     "node_modules/mjml-cli/node_modules/chokidar": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12081,8 +11583,6 @@
     },
     "node_modules/mjml-cli/node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -12094,8 +11594,6 @@
     },
     "node_modules/mjml-cli/node_modules/picomatch": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -12107,8 +11605,6 @@
     },
     "node_modules/mjml-cli/node_modules/readdirp": {
       "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12120,8 +11616,6 @@
     },
     "node_modules/mjml-column": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-column/-/mjml-column-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-h6tvdx9tPjADoRQ3hV5InTK7j0w93fIenWvLaFmGx6F0b+BF6Uie+3L5hgNLmsuHLWHEJuaKsiviklHNP87Lew==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12132,8 +11626,6 @@
     },
     "node_modules/mjml-core": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-core/-/mjml-core-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-7j+MZzO3gb7jezfLUy8eFmMez9ctTuLoFFbFQuCfab/7UMsEbeKxodPZ6tSuQNKUfNQzJnpZFRhPxVDrmTRUoA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12153,8 +11645,6 @@
     },
     "node_modules/mjml-divider": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-divider/-/mjml-divider-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-EvVhI8TnjFyr0RW7U50HZMm52fnbMYS7KO0SsQtdJ64srCthBPXG9el54Kjnf4qrHHoab+SYuHdIJg8oF9PPyg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12165,8 +11655,6 @@
     },
     "node_modules/mjml-group": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-group/-/mjml-group-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-PtqdxB28GUNlBD9NxfffHgx26TK4sRhBs7UJthZOAxz8JkaFBKgdax+6LJBlrK7ZoY4YtYdyY7yGnGA5g8DJ5g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12177,8 +11665,6 @@
     },
     "node_modules/mjml-head": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-head/-/mjml-head-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-Y4R8I4zLv3fbJR4sKR7iq9i1OwxhEmbuXWpWoBBXK9XftjABEEjYtuQNC66Rw47Jx2EfWKmG8E6AFMjm8DuLGA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12189,8 +11675,6 @@
     },
     "node_modules/mjml-head-attributes": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-head-attributes/-/mjml-head-attributes-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-QXVN9/K8y0c2v2oeP+iBmPeHEwkRMszX7rl6EmSHFHcoXPg0Ah50rlTydpocEjawuhG+2vKP7A7if0MVkVf8KQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12201,8 +11685,6 @@
     },
     "node_modules/mjml-head-breakpoint": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-head-breakpoint/-/mjml-head-breakpoint-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-25yyR6QMKcFmPvFbi/Qa/23AJk8gh7xEx+CHyPecIyMduCys0QRgI27XBTHoJq36ea10p17MD5SYmVboETjSVQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12213,8 +11695,6 @@
     },
     "node_modules/mjml-head-font": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-head-font/-/mjml-head-font-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-/fUORt3H7S9Lf2fMhOjKdChK7CVZSwTMna4tfzC0HnWIdWRB37++EBqxs01PmhgdkHkB/yj290cIpwb3q3T4pQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12225,8 +11705,6 @@
     },
     "node_modules/mjml-head-html-attributes": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-head-html-attributes/-/mjml-head-html-attributes-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-bQxWssXxxJ83gJEeJoa8SzqedMrIVAHLRGKqS7VeGPEGwjDsciP12l7Jinlb7AMHzR7VV0TOxd+FK7Ys43hbMg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12237,8 +11715,6 @@
     },
     "node_modules/mjml-head-preview": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-head-preview/-/mjml-head-preview-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-eSQt0ErwMrXY2Bh1NqL1dA/vjOLzy8JqbaAjjvjvQO9NCbBAXVSGCRWPZbp3wRYvHhPhWZ+GISSBQr18w2itTw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12249,8 +11725,6 @@
     },
     "node_modules/mjml-head-style": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-head-style/-/mjml-head-style-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-niZS4jR2QTYpQnRM937utgkQNfrIZZkbvLw9KQRxdLGQdpLC5r0oGpbTDLilW9UiTqkYoXdYwSBAEs5lqgY0Mg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12261,8 +11735,6 @@
     },
     "node_modules/mjml-head-title": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-head-title/-/mjml-head-title-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-EuzUnNXj1uIJWu0hrkbJY9akFtWxDUkJtRmUOtO6VDYa5mj/u3Wwb9Ed/RQOZOyvA7ft0n1fkDuxCmqEJynCfQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12273,8 +11745,6 @@
     },
     "node_modules/mjml-hero": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-hero/-/mjml-hero-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-BMuWuiI+eSWoizgL4aw/v620FFPWrjiM6jLfGKmTIkma/gnmRf0irshjW+BD7W8yq71ksHZQJEny/eZUUuy7DQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12285,8 +11755,6 @@
     },
     "node_modules/mjml-image": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-image/-/mjml-image-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-FRvjSNU9vMCNSw1pEalVbO7KnWbHzwflhns/hQdm/o4stkV7fEKrPW0Yh31hkwOYEyZzMXBoQyEHH0C5U4asHQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12297,8 +11765,6 @@
     },
     "node_modules/mjml-navbar": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-navbar/-/mjml-navbar-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-CWx35J+CnrTHax9kvIZxlHdFefhTiNKb1Sd2D4BaYdVRdtRzIlPVNoBvoxcSiATZbD+XNPpYgAO3+i7XbAVPMQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12309,8 +11775,6 @@
     },
     "node_modules/mjml-parser-xml": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-parser-xml/-/mjml-parser-xml-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-7jk6IcfwSWyUAa9wsK9GT9yA6Kit3l3h+STWFtrRMRdIEUmIiHN7UPDoUSNuSj3Zwg9XNHmHHz0lQtptBSm+Ag==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12322,8 +11786,6 @@
     },
     "node_modules/mjml-parser-xml/node_modules/htmlparser2": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
-      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -12342,8 +11804,6 @@
     },
     "node_modules/mjml-preset-core": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-preset-core/-/mjml-preset-core-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-ZdMZBFvx+DpUGUuQpYTkXpqoIZjEH824t3Kpj7lXbA+witVL8DCOJCKvCQssxcAP39MmfP3FJVm/SHiVVLPgTw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12377,8 +11837,6 @@
     },
     "node_modules/mjml-raw": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-raw/-/mjml-raw-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-aF6sbTW/kDYErHSAMOi9+8mGIsw721ebo9HEWkAkkp4YOiaLUiOmNUXy10bObOW7DKfUnI35afd5HxpNnkITWw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12389,8 +11847,6 @@
     },
     "node_modules/mjml-section": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-section/-/mjml-section-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-hzAbxdBWVB1GJ5IueKURzGQ5t9QEHaTTBsKtlvbAheFIx2VFCAPCs4oOZm4ZAj/0dIRyI3Cr3FNlsxkrF3x5Og==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12401,8 +11857,6 @@
     },
     "node_modules/mjml-social": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-social/-/mjml-social-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-QjGb0RV2wO+lPAMNUFN8ziQcfo6RI0qgolFSBylWNK7J33kXg9kT7fMr4EPEPTa0XH24A9J0x2RAhnlSAWFM2Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12413,8 +11867,6 @@
     },
     "node_modules/mjml-spacer": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-spacer/-/mjml-spacer-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-3HdF3QTSASf3FYU4AM1HPcQa2yDlHF6UpNjjitTM1v5s1TkgylshbR9QkcNQAtHWN1VmaeNwVSXuK9GGvAu3gQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12425,8 +11877,6 @@
     },
     "node_modules/mjml-table": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-table/-/mjml-table-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-C9aEyQhSdQcDjUbKGs5sYwSPfN68/W2prycfMt9y0hx0d6aJupHJSU+1u8Dfum+X/zdT2UjdHtJNYJK8VwD/0Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12437,8 +11887,6 @@
     },
     "node_modules/mjml-text": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-text/-/mjml-text-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-+AiY3LzWJuJS6P3CuDPTOCT2raA/6V3ko512VxWkbMeAyc1WXtPgFG6CcLjULE3o69e699njeVpE4x+yuVxo2g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12449,8 +11897,6 @@
     },
     "node_modules/mjml-validator": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-validator/-/mjml-validator-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-RX6iwFTtSzAUO4jLLntyA3AGz2L5jbENlYPijqHhyQ6pC0U4ysvXoz8w67SPdeHiEgCtmsyGd5kHniJ1OMJeDw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12459,8 +11905,6 @@
     },
     "node_modules/mjml-wrapper": {
       "version": "5.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/mjml-wrapper/-/mjml-wrapper-5.0.0-alpha.11.tgz",
-      "integrity": "sha512-p0XA5RX7JGoT6c5kcRtKELI9GEn6MIAD2BMJKd4JzRWdCPPoL69D7BUV88kyjmT6eoLELCTYoUsOsVXFE4EGXw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12480,8 +11924,6 @@
     },
     "node_modules/multer": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
-      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
@@ -12510,15 +11952,11 @@
     },
     "node_modules/mutation-testing-elements": {
       "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/mutation-testing-elements/-/mutation-testing-elements-3.7.2.tgz",
-      "integrity": "sha512-i7X2Q4X5eYon72W2QQ9HND7plVhQcqTnv+Xc3KeYslRZSJ4WYJoal8LFdbWm7dKWLNE0rYkCUrvboasWzF3MMA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/mutation-testing-metrics": {
       "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/mutation-testing-metrics/-/mutation-testing-metrics-3.7.2.tgz",
-      "integrity": "sha512-ichXZSC4FeJbcVHYOWzWUhNuTJGogc0WiQol8lqEBrBSp+ADl3fmcZMqrx0ogInEUiImn+A8JyTk6uh9vd25TQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -12527,8 +11965,6 @@
     },
     "node_modules/mutation-testing-report-schema": {
       "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/mutation-testing-report-schema/-/mutation-testing-report-schema-3.7.2.tgz",
-      "integrity": "sha512-fN5M61SDzIOeJyatMOhGPLDOFz5BQIjTNPjo4PcHIEUWrejO4i4B5PFuQ/2l43709hEsTxeiXX00H73WERKcDw==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -12542,8 +11978,6 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "devOptional": true,
       "funding": [
         {
@@ -12605,8 +12039,6 @@
     },
     "node_modules/nice-try": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "license": "MIT",
       "optional": true
     },
@@ -12652,6 +12084,7 @@
     "node_modules/nodemailer": {
       "version": "8.0.1",
       "license": "MIT-0",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -12677,8 +12110,6 @@
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -12738,8 +12169,6 @@
     },
     "node_modules/open": {
       "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
-      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12793,8 +12222,6 @@
     },
     "node_modules/p-event": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
-      "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12809,8 +12236,6 @@
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -12847,8 +12272,6 @@
     },
     "node_modules/p-timeout": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
-      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12868,8 +12291,6 @@
     },
     "node_modules/p-wait-for": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.2.0.tgz",
-      "integrity": "sha512-wpgERjNkLrBiFmkMEjuZJEWKKDrNfHCKA1OhyN1wg1FrLkULbviEy6py1AyJUgZ72YWFbZ38FIpnqvVqAlDUwA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12928,8 +12349,6 @@
     },
     "node_modules/parse5": {
       "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12941,8 +12360,6 @@
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
-      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12955,8 +12372,6 @@
     },
     "node_modules/parse5-parser-stream": {
       "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
-      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12968,8 +12383,6 @@
     },
     "node_modules/parse5/node_modules/entities": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "license": "BSD-2-Clause",
       "optional": true,
       "engines": {
@@ -13000,6 +12413,7 @@
     "node_modules/passport": {
       "version": "0.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -13053,15 +12467,11 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/path-scurry": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -13112,6 +12522,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -13288,8 +12699,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "devOptional": true,
       "funding": [
         {
@@ -13306,6 +12715,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13317,8 +12727,6 @@
     },
     "node_modules/postcss-calc": {
       "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-10.1.1.tgz",
-      "integrity": "sha512-NYEsLHh8DgG/PRH2+G9BTuUdtf9ViS+vdoQ0YA5OQdGsfN4ztiwtDWNtBl9EKeqNMFnIu8IKZ0cLxEQ5r5KVMw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13334,8 +12742,6 @@
     },
     "node_modules/postcss-colormin": {
       "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-7.0.5.tgz",
-      "integrity": "sha512-ekIBP/nwzRWhEMmIxHHbXHcMdzd1HIUzBECaj5KEdLz9DVP2HzT065sEhvOx1dkLjYW7jyD0CngThx6bpFi2fA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13353,8 +12759,6 @@
     },
     "node_modules/postcss-convert-values": {
       "version": "7.0.8",
-      "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-7.0.8.tgz",
-      "integrity": "sha512-+XNKuPfkHTCEo499VzLMYn94TiL3r9YqRE3Ty+jP7UX4qjewUONey1t7CG21lrlTLN07GtGM8MqFVp86D4uKJg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13370,8 +12774,6 @@
     },
     "node_modules/postcss-discard-comments": {
       "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.5.tgz",
-      "integrity": "sha512-IR2Eja8WfYgN5n32vEGSctVQ1+JARfu4UH8M7bgGh1bC+xI/obsPJXaBpQF7MAByvgwZinhpHpdrmXtvVVlKcQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13386,8 +12788,6 @@
     },
     "node_modules/postcss-discard-duplicates": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-7.0.2.tgz",
-      "integrity": "sha512-eTonaQvPZ/3i1ASDHOKkYwAybiM45zFIc7KXils4mQmHLqIswXD9XNOKEVxtTFnsmwYzF66u4LMgSr0abDlh5w==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -13399,8 +12799,6 @@
     },
     "node_modules/postcss-discard-empty": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.1.tgz",
-      "integrity": "sha512-cFrJKZvcg/uxB6Ijr4l6qmn3pXQBna9zyrPC+sK0zjbkDUZew+6xDltSF7OeB7rAtzaaMVYSdbod+sZOCWnMOg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -13412,8 +12810,6 @@
     },
     "node_modules/postcss-discard-overridden": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-7.0.1.tgz",
-      "integrity": "sha512-7c3MMjjSZ/qYrx3uc1940GSOzN1Iqjtlqe8uoSg+qdVPYyRb0TILSqqmtlSFuE4mTDECwsm397Ya7iXGzfF7lg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -13425,8 +12821,6 @@
     },
     "node_modules/postcss-merge-longhand": {
       "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-7.0.5.tgz",
-      "integrity": "sha512-Kpu5v4Ys6QI59FxmxtNB/iHUVDn9Y9sYw66D6+SZoIk4QTz1prC4aYkhIESu+ieG1iylod1f8MILMs1Em3mmIw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13442,8 +12836,6 @@
     },
     "node_modules/postcss-merge-rules": {
       "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-7.0.7.tgz",
-      "integrity": "sha512-njWJrd/Ms6XViwowaaCc+/vqhPG3SmXn725AGrnl+BgTuRPEacjiLEaGq16J6XirMJbtKkTwnt67SS+e2WGoew==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13461,8 +12853,6 @@
     },
     "node_modules/postcss-minify-font-values": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-7.0.1.tgz",
-      "integrity": "sha512-2m1uiuJeTplll+tq4ENOQSzB8LRnSUChBv7oSyFLsJRtUgAAJGP6LLz0/8lkinTgxrmJSPOEhgY1bMXOQ4ZXhQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13477,8 +12867,6 @@
     },
     "node_modules/postcss-minify-gradients": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-7.0.1.tgz",
-      "integrity": "sha512-X9JjaysZJwlqNkJbUDgOclyG3jZEpAMOfof6PUZjPnPrePnPG62pS17CjdM32uT1Uq1jFvNSff9l7kNbmMSL2A==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13495,8 +12883,6 @@
     },
     "node_modules/postcss-minify-params": {
       "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-7.0.5.tgz",
-      "integrity": "sha512-FGK9ky02h6Ighn3UihsyeAH5XmLEE2MSGH5Tc4tXMFtEDx7B+zTG6hD/+/cT+fbF7PbYojsmmWjyTwFwW1JKQQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13513,8 +12899,6 @@
     },
     "node_modules/postcss-minify-selectors": {
       "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-7.0.5.tgz",
-      "integrity": "sha512-x2/IvofHcdIrAm9Q+p06ZD1h6FPcQ32WtCRVodJLDR+WMn8EVHI1kvLxZuGKz/9EY5nAmI6lIQIrpo4tBy5+ug==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13530,8 +12914,6 @@
     },
     "node_modules/postcss-normalize-charset": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-7.0.1.tgz",
-      "integrity": "sha512-sn413ofhSQHlZFae//m9FTOfkmiZ+YQXsbosqOWRiVQncU2BA3daX3n0VF3cG6rGLSFVc5Di/yns0dFfh8NFgQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -13543,8 +12925,6 @@
     },
     "node_modules/postcss-normalize-display-values": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.1.tgz",
-      "integrity": "sha512-E5nnB26XjSYz/mGITm6JgiDpAbVuAkzXwLzRZtts19jHDUBFxZ0BkXAehy0uimrOjYJbocby4FVswA/5noOxrQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13559,8 +12939,6 @@
     },
     "node_modules/postcss-normalize-positions": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-7.0.1.tgz",
-      "integrity": "sha512-pB/SzrIP2l50ZIYu+yQZyMNmnAcwyYb9R1fVWPRxm4zcUFCY2ign7rcntGFuMXDdd9L2pPNUgoODDk91PzRZuQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13575,8 +12953,6 @@
     },
     "node_modules/postcss-normalize-repeat-style": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-7.0.1.tgz",
-      "integrity": "sha512-NsSQJ8zj8TIDiF0ig44Byo3Jk9e4gNt9x2VIlJudnQQ5DhWAHJPF4Tr1ITwyHio2BUi/I6Iv0HRO7beHYOloYQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13591,8 +12967,6 @@
     },
     "node_modules/postcss-normalize-string": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-7.0.1.tgz",
-      "integrity": "sha512-QByrI7hAhsoze992kpbMlJSbZ8FuCEc1OT9EFbZ6HldXNpsdpZr+YXC5di3UEv0+jeZlHbZcoCADgb7a+lPmmQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13607,8 +12981,6 @@
     },
     "node_modules/postcss-normalize-timing-functions": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-7.0.1.tgz",
-      "integrity": "sha512-bHifyuuSNdKKsnNJ0s8fmfLMlvsQwYVxIoUBnowIVl2ZAdrkYQNGVB4RxjfpvkMjipqvbz0u7feBZybkl/6NJg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13623,8 +12995,6 @@
     },
     "node_modules/postcss-normalize-unicode": {
       "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-7.0.5.tgz",
-      "integrity": "sha512-X6BBwiRxVaFHrb2WyBMddIeB5HBjJcAaUHyhLrM2FsxSq5TFqcHSsK7Zu1otag+o0ZphQGJewGH1tAyrD0zX1Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13640,8 +13010,6 @@
     },
     "node_modules/postcss-normalize-url": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-7.0.1.tgz",
-      "integrity": "sha512-sUcD2cWtyK1AOL/82Fwy1aIVm/wwj5SdZkgZ3QiUzSzQQofrbq15jWJ3BA7Z+yVRwamCjJgZJN0I9IS7c6tgeQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13656,8 +13024,6 @@
     },
     "node_modules/postcss-normalize-whitespace": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-7.0.1.tgz",
-      "integrity": "sha512-vsbgFHMFQrJBJKrUFJNZ2pgBeBkC2IvvoHjz1to0/0Xk7sII24T0qFOiJzG6Fu3zJoq/0yI4rKWi7WhApW+EFA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13672,8 +13038,6 @@
     },
     "node_modules/postcss-ordered-values": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-7.0.2.tgz",
-      "integrity": "sha512-AMJjt1ECBffF7CEON/Y0rekRLS6KsePU6PRP08UqYW4UGFRnTXNrByUzYK1h8AC7UWTZdQ9O3Oq9kFIhm0SFEw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13689,8 +13053,6 @@
     },
     "node_modules/postcss-reduce-initial": {
       "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-7.0.5.tgz",
-      "integrity": "sha512-RHagHLidG8hTZcnr4FpyMB2jtgd/OcyAazjMhoy5qmWJOx1uxKh4ntk0Pb46ajKM0rkf32lRH4C8c9qQiPR6IA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13706,8 +13068,6 @@
     },
     "node_modules/postcss-reduce-transforms": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-7.0.1.tgz",
-      "integrity": "sha512-MhyEbfrm+Mlp/36hvZ9mT9DaO7dbncU0CvWI8V93LRkY6IYlu38OPg3FObnuKTUxJ4qA8HpurdQOo5CyqqO76g==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13722,8 +13082,6 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13736,8 +13094,6 @@
     },
     "node_modules/postcss-svgo": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-7.1.0.tgz",
-      "integrity": "sha512-KnAlfmhtoLz6IuU3Sij2ycusNs4jPW+QoFE5kuuUOK8awR6tMxZQrs5Ey3BUz7nFCzT3eqyFgqkyrHiaU2xx3w==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13753,8 +13109,6 @@
     },
     "node_modules/postcss-unique-selectors": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-7.0.4.tgz",
-      "integrity": "sha512-pmlZjsmEAG7cHd7uK3ZiNSW6otSZ13RHuZ/4cDN/bVglS5EpF2r2oxY99SuOHa8m7AWoBCelTS3JPpzsIs8skQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -13769,8 +13123,6 @@
     },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -13807,8 +13159,6 @@
     },
     "node_modules/posthtml": {
       "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.7.tgz",
-      "integrity": "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13821,8 +13171,6 @@
     },
     "node_modules/posthtml-parser": {
       "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
-      "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13834,8 +13182,6 @@
     },
     "node_modules/posthtml-parser/node_modules/dom-serializer": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13849,8 +13195,6 @@
     },
     "node_modules/posthtml-parser/node_modules/dom-serializer/node_modules/entities": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "license": "BSD-2-Clause",
       "optional": true,
       "funding": {
@@ -13859,8 +13203,6 @@
     },
     "node_modules/posthtml-parser/node_modules/domhandler": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
       "license": "BSD-2-Clause",
       "optional": true,
       "dependencies": {
@@ -13875,8 +13217,6 @@
     },
     "node_modules/posthtml-parser/node_modules/domutils": {
       "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
       "license": "BSD-2-Clause",
       "optional": true,
       "dependencies": {
@@ -13890,8 +13230,6 @@
     },
     "node_modules/posthtml-parser/node_modules/entities": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
       "license": "BSD-2-Clause",
       "optional": true,
       "engines": {
@@ -13903,8 +13241,6 @@
     },
     "node_modules/posthtml-parser/node_modules/htmlparser2": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -13923,8 +13259,6 @@
     },
     "node_modules/posthtml-render": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
-      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13946,6 +13280,7 @@
       "version": "3.8.1",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14007,8 +13342,6 @@
     },
     "node_modules/preview-email": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/preview-email/-/preview-email-3.1.1.tgz",
-      "integrity": "sha512-nrdhnt+E9ClJ4khk9rNzqgsxubH7xSJSKoqXx/7aed2eghegNGNWkSGOelNgFgUtMz3LmKGks0waH2NuXWWmPg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14030,8 +13363,6 @@
     },
     "node_modules/preview-email/node_modules/ci-info": {
       "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
       "funding": [
         {
           "type": "github",
@@ -14046,8 +13377,6 @@
     },
     "node_modules/preview-email/node_modules/nodemailer": {
       "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
-      "integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
       "license": "MIT-0",
       "optional": true,
       "engines": {
@@ -14056,8 +13385,6 @@
     },
     "node_modules/preview-email/node_modules/uuid": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -14078,8 +13405,6 @@
     },
     "node_modules/promise": {
       "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14103,8 +13428,6 @@
     },
     "node_modules/pug": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pug/-/pug-3.0.3.tgz",
-      "integrity": "sha512-uBi6kmc9f3SZ3PXxqcHiUZLmIXgfgWooKWXcwSGwQd2Zi5Rb0bT14+8CJjJgI8AB+nndLaNgHGrcc6bPIB665g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14120,8 +13443,6 @@
     },
     "node_modules/pug-attrs": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pug-attrs/-/pug-attrs-3.0.0.tgz",
-      "integrity": "sha512-azINV9dUtzPMFQktvTXciNAfAuVh/L/JCl0vtPCwvOA21uZrC08K/UnmrL+SXGEVc1FwzjW62+xw5S/uaLj6cA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14132,8 +13453,6 @@
     },
     "node_modules/pug-code-gen": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-3.0.3.tgz",
-      "integrity": "sha512-cYQg0JW0w32Ux+XTeZnBEeuWrAY7/HNE6TWnhiHGnnRYlCgyAUPoyh9KzCMa9WhcJlJ1AtQqpEYHc+vbCzA+Aw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14149,15 +13468,11 @@
     },
     "node_modules/pug-error": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-2.1.0.tgz",
-      "integrity": "sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/pug-filters": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pug-filters/-/pug-filters-4.0.0.tgz",
-      "integrity": "sha512-yeNFtq5Yxmfz0f9z2rMXGw/8/4i1cCFecw/Q7+D0V2DdtII5UvqE12VaZ2AY7ri6o5RNXiweGH79OCq+2RQU4A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14170,8 +13485,6 @@
     },
     "node_modules/pug-lexer": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pug-lexer/-/pug-lexer-5.0.1.tgz",
-      "integrity": "sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14182,8 +13495,6 @@
     },
     "node_modules/pug-linker": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pug-linker/-/pug-linker-4.0.0.tgz",
-      "integrity": "sha512-gjD1yzp0yxbQqnzBAdlhbgoJL5qIFJw78juN1NpTLt/mfPJ5VgC4BvkoD3G23qKzJtIIXBbcCt6FioLSFLOHdw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14193,8 +13504,6 @@
     },
     "node_modules/pug-load": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pug-load/-/pug-load-3.0.0.tgz",
-      "integrity": "sha512-OCjTEnhLWZBvS4zni/WUMjH2YSUosnsmjGBB1An7CsKQarYSWQ0GCVyd4eQPMFJqZ8w9xgs01QdiZXKVjk92EQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14204,8 +13513,6 @@
     },
     "node_modules/pug-parser": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/pug-parser/-/pug-parser-6.0.0.tgz",
-      "integrity": "sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14215,15 +13522,11 @@
     },
     "node_modules/pug-runtime": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-3.0.1.tgz",
-      "integrity": "sha512-L50zbvrQ35TkpHwv0G6aLSuueDRwc/97XdY8kL3tOT0FmhgG7UypU3VztfV/LATAvmUfYi4wNxSajhSAeNN+Kg==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/pug-strip-comments": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pug-strip-comments/-/pug-strip-comments-2.0.0.tgz",
-      "integrity": "sha512-zo8DsDpH7eTkPHCXFeAk1xZXJbyoTfdPlNR0bK7rpOMuhBYb0f5qUVCO1xlsitYd3w5FQTK7zpNVKb3rZoUrrQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14232,15 +13535,11 @@
     },
     "node_modules/pug-walk": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-2.0.0.tgz",
-      "integrity": "sha512-yYELe9Q5q9IQhuvqsZNwA5hfPkMJ8u92bQLIMcsMxf/VADjNtEYptU+inlufAFYcWdHlwNfZOEnOOQrZrcyJCQ==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14249,8 +13548,6 @@
     },
     "node_modules/punycode.js": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14274,8 +13571,6 @@
     },
     "node_modules/qs": {
       "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -14337,8 +13632,6 @@
     },
     "node_modules/rc": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "optional": true,
       "dependencies": {
@@ -14353,8 +13646,6 @@
     },
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14409,7 +13700,8 @@
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -14439,8 +13731,6 @@
     },
     "node_modules/resolve": {
       "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14512,8 +13802,6 @@
     },
     "node_modules/rimraf": {
       "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
-      "integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -14546,8 +13834,6 @@
     },
     "node_modules/run-applescript": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-3.2.0.tgz",
-      "integrity": "sha512-Ep0RsvAjnRcBX1p5vogbaBdAGu/8j/ewpvGqnQYunnLd9SM0vWcPJewPKNnWFggf0hF0pwIgwV5XK7qQ7UZ8Qg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14559,8 +13845,6 @@
     },
     "node_modules/run-applescript/node_modules/cross-spawn": {
       "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
-      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14576,8 +13860,6 @@
     },
     "node_modules/run-applescript/node_modules/execa": {
       "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
-      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14595,8 +13877,6 @@
     },
     "node_modules/run-applescript/node_modules/get-stream": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14605,8 +13885,6 @@
     },
     "node_modules/run-applescript/node_modules/is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14615,8 +13893,6 @@
     },
     "node_modules/run-applescript/node_modules/npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14628,8 +13904,6 @@
     },
     "node_modules/run-applescript/node_modules/path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14638,8 +13912,6 @@
     },
     "node_modules/run-applescript/node_modules/semver": {
       "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -14648,8 +13920,6 @@
     },
     "node_modules/run-applescript/node_modules/shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -14661,8 +13931,6 @@
     },
     "node_modules/run-applescript/node_modules/shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14671,15 +13939,11 @@
     },
     "node_modules/run-applescript/node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC",
       "optional": true
     },
     "node_modules/run-applescript/node_modules/which": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -14713,6 +13977,7 @@
     "node_modules/rxjs": {
       "version": "7.8.2",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -14741,8 +14006,6 @@
     },
     "node_modules/sax": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
-      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
       "devOptional": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -14820,8 +14083,6 @@
     },
     "node_modules/serialize-javascript": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
-      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -14984,8 +14245,6 @@
     },
     "node_modules/slick": {
       "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
-      "integrity": "sha512-4qdtOGcBjral6YIBCWJ0ljFSKNLz9KkhbWtuGvUyRowl1kxfuE1x/Z/aJcaiilpb3do9bl5K7/1h9XC5wWpY/A==",
       "license": "MIT (http://mootools.net/license.txt)",
       "optional": true,
       "engines": {
@@ -15002,8 +14261,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -15140,8 +14397,6 @@
     },
     "node_modules/strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -15195,8 +14450,6 @@
     },
     "node_modules/stylehacks": {
       "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-7.0.7.tgz",
-      "integrity": "sha512-bJkD0JkEtbRrMFtwgpJyBbFIwfDDONQ1Ov3sDLZQP8HuJ73kBOyx66H4bOcAbVWmnfLdvQ0AJwXxOMkpujcO6g==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -15253,8 +14506,6 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -15266,10 +14517,9 @@
     },
     "node_modules/svgo": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "commander": "^11.1.0",
         "css-select": "^5.1.0",
@@ -15292,8 +14542,6 @@
     },
     "node_modules/svgo/node_modules/commander": {
       "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
@@ -15365,6 +14613,7 @@
       "version": "5.44.1",
       "devOptional": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -15479,8 +14728,6 @@
     },
     "node_modules/test-exclude": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
-      "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -15494,8 +14741,6 @@
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15511,8 +14756,6 @@
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15524,8 +14767,6 @@
     },
     "node_modules/tlds": {
       "version": "1.261.0",
-      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
-      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -15568,8 +14809,6 @@
     },
     "node_modules/token-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/token-stream/-/token-stream-1.0.0.tgz",
-      "integrity": "sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==",
       "license": "MIT",
       "optional": true
     },
@@ -15691,10 +14930,9 @@
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15735,8 +14973,6 @@
     },
     "node_modules/ts-node/node_modules/diff": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -15890,6 +15126,7 @@
     "node_modules/typeorm": {
       "version": "0.3.28",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -16034,6 +15271,7 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16044,13 +15282,12 @@
     },
     "node_modules/uc.micro": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "license": "MIT",
       "optional": true
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
+      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -16081,14 +15318,14 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.7",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/undici": {
       "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -16097,8 +15334,6 @@
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -16191,8 +15426,6 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -16227,8 +15460,6 @@
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -16247,8 +15478,6 @@
     },
     "node_modules/valid-data-url": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-3.0.1.tgz",
-      "integrity": "sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -16271,8 +15500,6 @@
     },
     "node_modules/void-elements": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
-      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -16309,15 +15536,11 @@
     },
     "node_modules/weapon-regex": {
       "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/weapon-regex/-/weapon-regex-1.3.6.tgz",
-      "integrity": "sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/web-resource-inliner": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/web-resource-inliner/-/web-resource-inliner-8.0.0.tgz",
-      "integrity": "sha512-Ezr98sqXW/+OCGoUEXuOKVR+oVFlSdn1tIySEEJdiSAw4IjrW8hQkwARSSBJTSB5Us5dnytDgL0ZDliAYBhaNA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16333,8 +15556,6 @@
     },
     "node_modules/web-resource-inliner/node_modules/htmlparser2": {
       "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
-      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -16355,6 +15576,7 @@
       "version": "5.104.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -16489,9 +15711,6 @@
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16503,8 +15722,6 @@
     },
     "node_modules/whatwg-encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16516,8 +15733,6 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -16568,8 +15783,6 @@
     },
     "node_modules/with": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/with/-/with-7.0.2.tgz",
-      "integrity": "sha512-RNGKj82nUPg3g5ygxkQl0R937xLyho1J24ItRCBTr/m1YnZkzJy1hUiHUJrc/VlsDQzsCnInEGSg3bci0Lmd4w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16626,8 +15839,6 @@
     },
     "node_modules/xml": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
-      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true,
       "license": "MIT"
     },
@@ -16647,8 +15858,6 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },
@@ -16677,8 +15886,6 @@
     },
     "node_modules/yn": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
       "devOptional": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -154,7 +154,8 @@
     "glob": "^13.0.0",
     "fast-xml-parser": "^5.4.1",
     "mjml": "^5.0.0-alpha.11",
-    "serialize-javascript": "^7.0.3"
+    "serialize-javascript": "^7.0.3",
+    "underscore": "^1.13.8"
   },
   "eslintConfig": {
     "root": true,


### PR DESCRIPTION
## Description

This pull request addresses dependency vulnerabilities by adding a new override for `underscore` and updating existing security documentation.

Specifically:
- **Adds `underscore` override**: Introduces a `package.json` override to enforce `underscore: ^1.13.8`. This mitigates a high-severity Denial of Service vulnerability (GHSA-qpx9-hpmf-5gmw) caused by uncontrolled recursion in `underscore` versions older than `1.13.8`, which was pulled in via a devDependency chain.
- **Clarifies `multer` override documentation**: Updates the `docs/security.md` entry for `multer`. It now explains that `@nestjs/platform-express` has addressed the upstream vulnerability by pinning `multer` to `2.1.1`, but the local override and postinstall patch are retained to automatically incorporate future patch releases.
- **Updates security documentation**: The `docs/security.md` file now includes a dedicated section for the `underscore` vulnerability, detailing its root cause, scope, and removal conditions.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Breaking change (explain below)
- [x] Chore

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [x] I have updated the documentation where necessary.
- [x] I have considered the security implications of these changes.
- [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

This change also includes general dependency version bumps as reflected in `package-lock.json`, including an update to `express-rate-limit` and other general dependency enhancements.

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>