### PR TITLE
chore(deps): Harden dependency overrides and update security documentation

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -20,13 +20,13 @@ Current overrides in `package.json`:
 
 ```json
 "overrides": {
-  "file-type": "^21.3.1",
+  "file-type": "^21.3.2",
+  "flatted": "^3.4.1",
   "ajv": "^8.18.0",
   "svgo": "^4.0.1",
   "eslint": {
     "ajv": "^6.14.0"
   },
-  "minimatch": "^10.2.4",
   "test-exclude": "^8.0.0",
   "glob": "^13.0.0",
   "fast-xml-parser": "^5.4.1",
@@ -38,11 +38,11 @@ Current overrides in `package.json`:
 
 #### `file-type`
 
-- **Vulnerability**: [GHSA-5v7r-6r5c-r473](https://github.com/advisories/GHSA-5v7r-6r5c-r473) — Infinite loop in the ASF parser on malformed input with a zero-size sub-header in `file-type 13.0.0 – 21.3.0`.
-- **Root cause**: `@nestjs/common` depends on `file-type` and resolves to `21.3.0`, which falls within the affected range. `npm audit fix --force` would downgrade `@nestjs/common` to `11.0.15`, which is a breaking change. The patched release `21.3.1` resolves the issue without touching the NestJS version.
-- **Override**: `"file-type": "^21.3.1"` — forces the patched release across the entire tree.
+- **Vulnerability**: [GHSA-j47w-4g3g-c36v](https://github.com/advisories/GHSA-j47w-4g3g-c36v) — ZIP decompression bomb DoS in `file-type >=20.0.0 <=21.3.1`.
+- **Root cause**: `@nestjs/common` requests `file-type@21.3.0`. `npm audit fix --force` would downgrade `@nestjs/common` to `11.0.15`, which is a breaking change.
+- **Override**: `"file-type": "^21.3.2"` — forces the patched release across the entire tree.
 
-**When it can be removed**: When `@nestjs/common` updates its own `file-type` dependency to `>= 21.3.1` natively. Verify by removing the override and running `npm audit --omit=dev --audit-level=high`. Check the upstream version with:
+**When it can be removed**: When `@nestjs/common` updates its own `file-type` dependency to `>= 21.3.2` natively. Verify by removing the override and running `npm audit --omit=dev --audit-level=high`. Check the upstream version with:
 
 ```sh
 npm view @nestjs/common@latest dependencies.file-type
@@ -67,6 +67,14 @@ npm view @nestjs/platform-express@latest dependencies.multer
 
 **When it can be removed**: When all packages that transitively depend on `ajv` have updated to request `>= 8.18.0` natively. Verify by removing the override and checking `npm audit --omit=dev --audit-level=high`. The ESLint nested override can be removed when ESLint migrates away from `ajv@6`.
 
+#### `flatted`
+
+- **Vulnerability**: [GHSA-25h7-pfq9-p65f](https://github.com/advisories/GHSA-25h7-pfq9-p65f) — unbounded recursion DoS in `flatted < 3.4.0`.
+- **Root cause**: ESLint's cache chain (`eslint -> file-entry-cache -> flat-cache`) previously resolved to `flatted@3.3.3`.
+- **Override**: `"flatted": "^3.4.1"` — forces a safe release in the full dependency tree.
+
+**When it can be removed**: When all transitive consumers request `flatted >= 3.4.0` natively. Verify by removing the override and running full `npm audit`.
+
 #### `svgo`
 
 - **Vulnerability**: [GHSA-xpqw-6gx7-v673](https://github.com/advisories/GHSA-xpqw-6gx7-v673) — Denial of Service via entity expansion (Billion Laughs attack) in `svgo < 4.0.1`.
@@ -75,13 +83,18 @@ npm view @nestjs/platform-express@latest dependencies.multer
 
 **When it can be removed**: When `postcss-svgo` updates its own `svgo` dependency to `>= 4.0.1`.
 
-#### `minimatch`, `glob`, and `test-exclude`
+#### `glob` and `test-exclude`
 
-- **Vulnerability**: `minimatch < 10.2.4` and `glob < 13` have high-severity ReDoS advisories.
-- **Solution**: Pin `minimatch` to `^10.2.4` and `glob` to `^13.0.0`. The key transitive offenders are `fork-ts-checker-webpack-plugin` (`minimatch@^3`) and the Jest reporter stack (`glob@^10`).
+- **Vulnerability**: `glob < 13` has high-severity ReDoS advisories.
+- **Solution**: Pin `glob` to `^13.0.0`. The key transitive offender is the Jest reporter stack (`glob@^10`).
 - **Compatibility**: Istanbul's `babel-plugin-istanbul` pulls in `test-exclude@^6`, which expects an older `minimatch` API. Overriding `test-exclude` to `^8.0.0` keeps coverage tooling working with the newer `minimatch` and `glob` versions, preventing `TypeError: minimatch is not a function` errors during Jest runs.
 
-**When it can be removed**: When `fork-ts-checker-webpack-plugin`, the Jest packages, and `babel-plugin-istanbul` have all updated their own `minimatch`/`glob`/`test-exclude` dependencies to versions that satisfy the above ranges natively. Verify with `npm audit` and `npm run test:cov`.
+**When it can be removed**: When Jest and Istanbul transitive dependencies request patched `glob`/`test-exclude` ranges natively. Verify with `npm audit` and `npm run test:cov`.
+
+#### `minimatch` — **removed from overrides**
+
+- **Removed**: The `minimatch` override was removed because the current resolved tree already installs `minimatch@10.2.4` natively.
+- **Validation**: `npm audit` and `npm run verify` remain clean after removal.
 
 #### `fast-xml-parser`
 
@@ -92,7 +105,7 @@ npm view @nestjs/platform-express@latest dependencies.multer
 
 #### `mjml`
 
-- **Purpose**: Forces `mjml` to `^5.0.0-alpha.11` (v5 prerelease) rather than the `^4.x` version that `@nestjs-modules/mailer` requests as an optional dependency.
+- **Purpose**: Forces `mjml` to `^5.0.0-beta.1` (v5 prerelease) rather than the `^4.x` version that `@nestjs-modules/mailer` requests as an optional dependency.
 - **Reason**: mjml v5 is required for compatibility with the email template rendering pipeline.
 
 **When it can be removed**: When `@nestjs-modules/mailer` officially supports and requests `mjml@^5` in its own dependencies, or when the project migrates away from mjml.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@aws-sdk/client-s3": "^3.1008.0",
+        "@aws-sdk/client-s3": "^3.1009.0",
         "@aws-sdk/client-secrets-manager": "^3.1009.0",
-        "@aws-sdk/client-sesv2": "^3.1008.0",
+        "@aws-sdk/client-sesv2": "^3.1009.0",
         "@nestjs-modules/mailer": "^2.0.2",
         "@nestjs/common": "^11.1.16",
         "@nestjs/config": "^4.0.3",
@@ -389,65 +389,65 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1008.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1008.0.tgz",
-      "integrity": "sha512-w/SIRD25v2zVMbkn8CYIxUsac8yf5Jghkhw5j7EsNWdJhl56m/nWpUX7t1etFUW1cnzpFjZV0lXt0dNFSnbXwA==",
+      "version": "3.1009.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1009.0.tgz",
+      "integrity": "sha512-luy8CxallkoiGWTqU86ca/BbvkWJjs0oala7uIIRN1JtQxMb5i4Yl/PBZVcQFhbK9kQi0PK0GfD8gIpLkI91fw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/credential-provider-node": "^3.972.20",
-        "@aws-sdk/middleware-bucket-endpoint": "^3.972.7",
-        "@aws-sdk/middleware-expect-continue": "^3.972.7",
-        "@aws-sdk/middleware-flexible-checksums": "^3.973.5",
-        "@aws-sdk/middleware-host-header": "^3.972.7",
-        "@aws-sdk/middleware-location-constraint": "^3.972.7",
-        "@aws-sdk/middleware-logger": "^3.972.7",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
-        "@aws-sdk/middleware-sdk-s3": "^3.972.19",
-        "@aws-sdk/middleware-ssec": "^3.972.7",
-        "@aws-sdk/middleware-user-agent": "^3.972.20",
-        "@aws-sdk/region-config-resolver": "^3.972.7",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/util-endpoints": "^3.996.4",
-        "@aws-sdk/util-user-agent-browser": "^3.972.7",
-        "@aws-sdk/util-user-agent-node": "^3.973.6",
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/core": "^3.23.9",
-        "@smithy/eventstream-serde-browser": "^4.2.11",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.11",
-        "@smithy/eventstream-serde-node": "^4.2.11",
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/hash-blob-browser": "^4.2.12",
-        "@smithy/hash-node": "^4.2.11",
-        "@smithy/hash-stream-node": "^4.2.11",
-        "@smithy/invalid-dependency": "^4.2.11",
-        "@smithy/md5-js": "^4.2.11",
-        "@smithy/middleware-content-length": "^4.2.11",
-        "@smithy/middleware-endpoint": "^4.4.23",
-        "@smithy/middleware-retry": "^4.4.40",
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/middleware-stack": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/credential-provider-node": "^3.972.21",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.8",
+        "@aws-sdk/middleware-expect-continue": "^3.972.8",
+        "@aws-sdk/middleware-flexible-checksums": "^3.973.6",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-location-constraint": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.20",
+        "@aws-sdk/middleware-ssec": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.21",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.11",
+        "@smithy/eventstream-serde-browser": "^4.2.12",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.12",
+        "@smithy/eventstream-serde-node": "^4.2.12",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-blob-browser": "^4.2.13",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/hash-stream-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/md5-js": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.25",
+        "@smithy/middleware-retry": "^4.4.42",
+        "@smithy/middleware-serde": "^4.2.14",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.39",
-        "@smithy/util-defaults-mode-node": "^4.2.42",
-        "@smithy/util-endpoints": "^3.3.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-retry": "^4.2.11",
-        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-defaults-mode-browser": "^4.3.41",
+        "@smithy/util-defaults-mode-node": "^4.2.44",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
+        "@smithy/util-stream": "^4.5.19",
         "@smithy/util-utf8": "^4.2.2",
-        "@smithy/util-waiter": "^4.2.12",
+        "@smithy/util-waiter": "^4.2.13",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -505,49 +505,49 @@
       }
     },
     "node_modules/@aws-sdk/client-sesv2": {
-      "version": "3.1008.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.1008.0.tgz",
-      "integrity": "sha512-a9WJ/EC8iwj1xN7Jz5zzZkw2EqEjh469j5ZahFSQEc8RmI28gpECV1QsagktII0fmTMpvHuM0ab6O7IiD4a3Wg==",
+      "version": "3.1009.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.1009.0.tgz",
+      "integrity": "sha512-Vb+Yx/L3GKw/A81Vq+hodnkOExcqPnnoqqro+ekmpgEnbVlISSW69zk2Ok34wsO312WalkHsVVHU8uhyp8nXuQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/credential-provider-node": "^3.972.20",
-        "@aws-sdk/middleware-host-header": "^3.972.7",
-        "@aws-sdk/middleware-logger": "^3.972.7",
-        "@aws-sdk/middleware-recursion-detection": "^3.972.7",
-        "@aws-sdk/middleware-user-agent": "^3.972.20",
-        "@aws-sdk/region-config-resolver": "^3.972.7",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.7",
-        "@aws-sdk/types": "^3.973.5",
-        "@aws-sdk/util-endpoints": "^3.996.4",
-        "@aws-sdk/util-user-agent-browser": "^3.972.7",
-        "@aws-sdk/util-user-agent-node": "^3.973.6",
-        "@smithy/config-resolver": "^4.4.10",
-        "@smithy/core": "^3.23.9",
-        "@smithy/fetch-http-handler": "^5.3.13",
-        "@smithy/hash-node": "^4.2.11",
-        "@smithy/invalid-dependency": "^4.2.11",
-        "@smithy/middleware-content-length": "^4.2.11",
-        "@smithy/middleware-endpoint": "^4.4.23",
-        "@smithy/middleware-retry": "^4.4.40",
-        "@smithy/middleware-serde": "^4.2.12",
-        "@smithy/middleware-stack": "^4.2.11",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/node-http-handler": "^4.4.14",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
-        "@smithy/url-parser": "^4.2.11",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/credential-provider-node": "^3.972.21",
+        "@aws-sdk/middleware-host-header": "^3.972.8",
+        "@aws-sdk/middleware-logger": "^3.972.8",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.8",
+        "@aws-sdk/middleware-user-agent": "^3.972.21",
+        "@aws-sdk/region-config-resolver": "^3.972.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.8",
+        "@aws-sdk/types": "^3.973.6",
+        "@aws-sdk/util-endpoints": "^3.996.5",
+        "@aws-sdk/util-user-agent-browser": "^3.972.8",
+        "@aws-sdk/util-user-agent-node": "^3.973.7",
+        "@smithy/config-resolver": "^4.4.11",
+        "@smithy/core": "^3.23.11",
+        "@smithy/fetch-http-handler": "^5.3.15",
+        "@smithy/hash-node": "^4.2.12",
+        "@smithy/invalid-dependency": "^4.2.12",
+        "@smithy/middleware-content-length": "^4.2.12",
+        "@smithy/middleware-endpoint": "^4.4.25",
+        "@smithy/middleware-retry": "^4.4.42",
+        "@smithy/middleware-serde": "^4.2.14",
+        "@smithy/middleware-stack": "^4.2.12",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/node-http-handler": "^4.4.16",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
+        "@smithy/url-parser": "^4.2.12",
         "@smithy/util-base64": "^4.3.2",
         "@smithy/util-body-length-browser": "^4.2.2",
         "@smithy/util-body-length-node": "^4.2.3",
-        "@smithy/util-defaults-mode-browser": "^4.3.39",
-        "@smithy/util-defaults-mode-node": "^4.2.42",
-        "@smithy/util-endpoints": "^3.3.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-retry": "^4.2.11",
+        "@smithy/util-defaults-mode-browser": "^4.3.41",
+        "@smithy/util-defaults-mode-node": "^4.2.44",
+        "@smithy/util-endpoints": "^3.3.3",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-retry": "^4.2.12",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -580,12 +580,12 @@
       }
     },
     "node_modules/@aws-sdk/crc64-nvme": {
-      "version": "3.972.4",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.4.tgz",
-      "integrity": "sha512-HKZIZLbRyvzo/bXZU7Zmk6XqU+1C9DjI56xd02vwuDIxedxBEqP17t9ExhbP9QFeNq/a3l9GOcyirFXxmbDhmw==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.5.tgz",
+      "integrity": "sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -751,16 +751,16 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.7.tgz",
-      "integrity": "sha512-goX+axlJ6PQlRnzE2bQisZ8wVrlm6dXJfBzMJhd8LhAIBan/w1Kl73fJnalM/S+18VnpzIHumyV6DtgmvqG5IA==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.8.tgz",
+      "integrity": "sha512-WR525Rr2QJSETa9a050isktyWi/4yIGcmY3BQ1kpHqb0LqUglQHCS8R27dTJxxWNZvQ0RVGtEZjTCbZJpyF3Aw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/types": "^3.973.6",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -769,14 +769,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.7.tgz",
-      "integrity": "sha512-mvWqvm61bmZUKmmrtl2uWbokqpenY3Mc3Jf4nXB/Hse6gWxLPaCQThmhPBDzsPSV8/Odn8V6ovWt3pZ7vy4BFQ==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.8.tgz",
+      "integrity": "sha512-5DTBTiotEES1e2jOHAq//zyzCjeMB78lEHd35u15qnrid4Nxm7diqIf9fQQ3Ov0ChH1V3Vvt13thOnrACmfGVQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -784,23 +784,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.973.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.973.5.tgz",
-      "integrity": "sha512-Dp3hqE5W6hG8HQ3Uh+AINx9wjjqYmFHbxede54sGj3akx/haIQrkp85lNdTdC+ouNUcSYNiuGkzmyDREfHX1Gg==",
+      "version": "3.973.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.973.6.tgz",
+      "integrity": "sha512-0nYEgkJH7Yt9k+nZJyllTghnkKaz17TWFcr5Mi0XMVMzYlF4ytDZADQpF2/iJo36cKL5AYSzRsvlykE4M/ErTA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/crc64-nvme": "^3.972.4",
-        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/crc64-nvme": "^3.972.5",
+        "@aws-sdk/types": "^3.973.6",
         "@smithy/is-array-buffer": "^4.2.2",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/types": "^4.13.0",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-stream": "^4.5.17",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/types": "^4.13.1",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.19",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -824,13 +824,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.7.tgz",
-      "integrity": "sha512-vdK1LJfffBp87Lj0Bw3WdK1rJk9OLDYdQpqoKgmpIZPe+4+HawZ6THTbvjhJt4C4MNnRrHTKHQjkwBiIpDBoig==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.8.tgz",
+      "integrity": "sha512-KaUoFuoFPziIa98DSQsTPeke1gvGXlc5ZGMhy+b+nLxZ4A7jmJgLzjEF95l8aOQN2T/qlPP3MrAyELm8ExXucw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -868,23 +868,23 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.19",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.19.tgz",
-      "integrity": "sha512-/CtOHHVFg4ZuN6CnLnYkrqWgVEnbOBC4kNiKa+4fldJ9cioDt3dD/f5vpq0cWLOXwmGL2zgVrVxNhjxWpxNMkg==",
+      "version": "3.972.20",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.20.tgz",
+      "integrity": "sha512-yhva/xL5H4tWQgsBjwV+RRD0ByCzg0TcByDCLp3GXdn/wlyRNfy8zsswDtCvr1WSKQkSQYlyEzPuWkJG0f5HvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.973.19",
-        "@aws-sdk/types": "^3.973.5",
+        "@aws-sdk/core": "^3.973.20",
+        "@aws-sdk/types": "^3.973.6",
         "@aws-sdk/util-arn-parser": "^3.972.3",
-        "@smithy/core": "^3.23.9",
-        "@smithy/node-config-provider": "^4.3.11",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/signature-v4": "^5.3.11",
-        "@smithy/smithy-client": "^4.12.3",
-        "@smithy/types": "^4.13.0",
+        "@smithy/core": "^3.23.11",
+        "@smithy/node-config-provider": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/smithy-client": "^4.12.5",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-config-provider": "^4.2.2",
-        "@smithy/util-middleware": "^4.2.11",
-        "@smithy/util-stream": "^4.5.17",
+        "@smithy/util-middleware": "^4.2.12",
+        "@smithy/util-stream": "^4.5.19",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -893,13 +893,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.972.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.7.tgz",
-      "integrity": "sha512-G9clGVuAml7d8DYzY6DnRi7TIIDRvZ3YpqJPz/8wnWS5fYx/FNWNmkO6iJVlVkQg9BfeMzd+bVPtPJOvC4B+nQ==",
+      "version": "3.972.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.8.tgz",
+      "integrity": "sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -991,16 +991,16 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.7.tgz",
-      "integrity": "sha512-mYhh7FY+7OOqjkYkd6+6GgJOsXK1xBWmuR+c5mxJPj2kr5TBNeZq+nUvE9kANWAux5UxDVrNOSiEM/wlHzC3Lg==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.8.tgz",
+      "integrity": "sha512-n1qYFD+tbqZuyskVaxUE+t10AUz9g3qzDw3Tp6QZDKmqsjfDmZBd4GIk2EKJJNtcCBtE5YiUjDYA+3djFAFBBg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.19",
-        "@aws-sdk/types": "^3.973.5",
-        "@smithy/protocol-http": "^5.3.11",
-        "@smithy/signature-v4": "^5.3.11",
-        "@smithy/types": "^4.13.0",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.20",
+        "@aws-sdk/types": "^3.973.6",
+        "@smithy/protocol-http": "^5.3.12",
+        "@smithy/signature-v4": "^5.3.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1161,6 +1161,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1747,6 +1748,8 @@
     },
     "node_modules/@babel/runtime": {
       "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3209,6 +3212,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.16.tgz",
       "integrity": "sha512-JSIeW+USuMJkkcNbiOdcPkVCeI3TSnXstIVEPpp3HiaKnPRuSbUUKm9TY9o/XpIcPHWUOQItAtC5BiAwFdVITQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -3264,6 +3268,7 @@
       "integrity": "sha512-tXWXyCiqWthelJjrE0KLFjf0O98VEt+WPVx5CrqCf+059kIxJ8y1Vw7Cy7N4fwQafWNrmFL2AfN87DDMbVAY0w==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3323,6 +3328,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.16.tgz",
       "integrity": "sha512-IOegr5+ZfUiMKgk+garsSU4MOkPRhm46e6w8Bp1GcO4vCdl9Piz6FlWAzKVfa/U3Hn/DdzSVJOW3TWcQQFdBDw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3573,6 +3579,7 @@
     "node_modules/@nestjs/typeorm": {
       "version": "11.0.0",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -3637,6 +3644,7 @@
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3656,6 +3664,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz",
       "integrity": "sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -3668,6 +3677,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
       "integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -4103,6 +4113,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
       "integrity": "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4119,6 +4130,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz",
       "integrity": "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.0",
         "@opentelemetry/resources": "2.6.0",
@@ -4134,6 +4146,7 @@
     "node_modules/@opentelemetry/semantic-conventions": {
       "version": "1.39.0",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -4536,13 +4549,13 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.11.tgz",
-      "integrity": "sha512-Sf39Ml0iVX+ba/bgMPxaXWAAFmHqYLTmbjAPfLPLY8CrYkRDEqZdUsKC1OwVMCdJXfAt0v4j49GIJ8DoSYAe6w==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.12.tgz",
+      "integrity": "sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-hex-encoding": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -4551,13 +4564,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.11.tgz",
-      "integrity": "sha512-3rEpo3G6f/nRS7fQDsZmxw/ius6rnlIpz4UX6FlALEzz8JoSxFmdBt0SZnthis+km7sQo6q5/3e+UJcuQivoXA==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.12.tgz",
+      "integrity": "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4565,12 +4578,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.3.11",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.11.tgz",
-      "integrity": "sha512-XeNIA8tcP/GDWnnKkO7qEm/bg0B/bP9lvIXZBXcGZwZ+VYM8h8k9wuDvUODtdQ2Wcp2RcBkPTCSMmaniVHrMlA==",
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.12.tgz",
+      "integrity": "sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4578,13 +4591,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.11.tgz",
-      "integrity": "sha512-fzbCh18rscBDTQSCrsp1fGcclLNF//nJyhjldsEl/5wCYmgpHblv5JSppQAyQI24lClsFT0wV06N1Porn0IsEw==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.12.tgz",
+      "integrity": "sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/eventstream-serde-universal": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4592,13 +4605,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.11.tgz",
-      "integrity": "sha512-MJ7HcI+jEkqoWT5vp+uoVaAjBrmxBtKhZTeynDRG/seEjJfqyg3SiqMMqyPnAMzmIfLaeJ/uiuSDP/l9AnMy/Q==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.12.tgz",
+      "integrity": "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/eventstream-codec": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4622,14 +4635,14 @@
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.12.tgz",
-      "integrity": "sha512-1wQE33DsxkM/waftAhCH9VtJbUGyt1PJ9YRDpOu+q9FUi73LLFUZ2fD8A61g2mT1UY9k7b99+V1xZ41Rz4SHRQ==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.13.tgz",
+      "integrity": "sha512-YrF4zWKh+ghLuquldj6e/RzE3xZYL8wIPfkt0MqCRphVICjyyjH8OwKD7LLlKpVEbk4FLizFfC1+gwK6XQdR3g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/chunked-blob-reader": "^5.2.2",
         "@smithy/chunked-blob-reader-native": "^4.2.3",
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4652,12 +4665,12 @@
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.11.tgz",
-      "integrity": "sha512-hQsTjwPCRY8w9GK07w1RqJi3e+myh0UaOWBBhZ1UMSDgofH/Q1fEYzU1teaX6HkpX/eWDdm7tAGR0jBPlz9QEQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.12.tgz",
+      "integrity": "sha512-O3YbmGExeafuM/kP7Y8r6+1y0hIh3/zn6GROx0uNlB54K9oihAL75Qtc+jFfLNliTi6pxOAYZrRKD9A7iA6UFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -4689,12 +4702,12 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.11.tgz",
-      "integrity": "sha512-350X4kGIrty0Snx2OWv7rPM6p6vM7RzryvFs6B/56Cux3w3sChOb3bymo5oidXJlPcP9fIRxGUCk7GqpiSOtng==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.12.tgz",
+      "integrity": "sha512-W/oIpHCpWU2+iAkfZYyGWE+qkpuf3vEXHLxQQDx9FPNZTTdnul0dZ2d/gUFrtQ5je1G2kp4cjG0/24YueG2LbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
+        "@smithy/types": "^4.13.1",
         "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
@@ -5135,13 +5148,13 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.2.12",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.12.tgz",
-      "integrity": "sha512-ek5hyDrzS6mBFsNCEX8LpM+EWSLq6b9FdmPRlkpXXhiJE6aIZehKT9clC6+nFpZAA+i/Yg0xlaPeWGNbf5rzQA==",
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.13.tgz",
+      "integrity": "sha512-2zdZ9DTHngRtcYxJK1GUDxruNr53kv5W2Lupe0LMU+Imr6ohQg8M2T14MNkj1Y0wS3FFwpgpGQyvuaMF7CiTmQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.11",
-        "@smithy/types": "^4.13.0",
+        "@smithy/abort-controller": "^4.2.12",
+        "@smithy/types": "^4.13.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5180,6 +5193,7 @@
       "version": "9.6.0",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@inquirer/prompts": "^8.0.0",
         "@stryker-mutator/api": "9.6.0",
@@ -5925,6 +5939,7 @@
       "version": "9.6.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -6075,6 +6090,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -6152,6 +6168,8 @@
     },
     "node_modules/@types/relateurl": {
       "version": "0.2.33",
+      "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.33.tgz",
+      "integrity": "sha512-bTQCKsVbIdzLqZhLkF5fcJQreE4y1ro4DIyVrlDNSCJRRwHhB8Z+4zXXa8jN6eDvc2HbRsEYgbvrnGvi54EpSw==",
       "license": "MIT",
       "optional": true
     },
@@ -6262,6 +6280,7 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -6899,6 +6918,7 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6947,6 +6967,7 @@
       "version": "8.18.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7322,6 +7343,8 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -7384,6 +7407,8 @@
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "devOptional": true,
       "license": "ISC"
     },
@@ -7486,6 +7511,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7701,6 +7727,8 @@
     },
     "node_modules/cheerio": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0.tgz",
+      "integrity": "sha512-quS9HgjQpdaXOvsZz82Oz7uxtXiy6UIsIQcpBj7HRw2M63Skasm9qlDocAM7jNuaxdhpPU7c4kJN+gA5MCu4ww==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -7725,6 +7753,8 @@
     },
     "node_modules/cheerio-select": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
       "license": "BSD-2-Clause",
       "optional": true,
       "dependencies": {
@@ -7741,6 +7771,8 @@
     },
     "node_modules/cheerio/node_modules/htmlparser2": {
       "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -7761,6 +7793,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -7799,11 +7832,13 @@
     },
     "node_modules/class-transformer": {
       "version": "0.5.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -8008,6 +8043,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-stream": {
       "version": "2.0.0",
       "engines": [
@@ -8189,6 +8231,8 @@
     },
     "node_modules/css-select": {
       "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
       "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -8242,6 +8286,7 @@
       "integrity": "sha512-mLFHQAzyapMVFLiJIn7Ef4C2UCEvtlTlbyILR6B5ZsUAV3D/Pa761R5uC1YPhyBkRd3eqaDm2ncaNrD7R4mTRg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssnano-preset-default": "^7.0.11",
         "lilconfig": "^3.1.3"
@@ -8304,6 +8349,8 @@
     },
     "node_modules/cssnano-preset-lite": {
       "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/cssnano-preset-lite/-/cssnano-preset-lite-4.0.4.tgz",
+      "integrity": "sha512-iV7xT9JEk0OJwRWuSV2Y48IkntNjvoiscoioFDcgmuoIvpZV8gIg1++GBHTj72HgmDCALH8y9ELgt+aFM2Nh9g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8485,6 +8532,8 @@
     },
     "node_modules/detect-node": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
       "license": "MIT",
       "optional": true
     },
@@ -8672,6 +8721,8 @@
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8684,6 +8735,8 @@
     },
     "node_modules/encoding-sniffer/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8717,6 +8770,8 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8782,6 +8837,8 @@
     },
     "node_modules/escape-goat": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-3.0.0.tgz",
+      "integrity": "sha512-w3PwNZJwRxlp47QGzhuEBldEqVHHhh8/tIPcl6ecf2Bou99cdAt0knihBV0Ecc7CGxYduXVBDheH1K2oADRlvw==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8820,6 +8877,7 @@
       "integrity": "sha512-COV33RzXZkqhG9P2rZCFl9ZmJ7WL+gQSCRzE7RhkbclbQPtLAWReL7ysA0Sh4c8Im2U9ynybdR56PV0XcKvqaQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -8874,6 +8932,7 @@
       "version": "10.1.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9144,6 +9203,7 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9187,6 +9247,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
       "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "10.1.0"
       },
@@ -9430,9 +9491,9 @@
       }
     },
     "node_modules/file-type": {
-      "version": "21.3.1",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.1.tgz",
-      "integrity": "sha512-SrzXX46I/zsRDjTb82eucsGg0ODq2NpGDp4HcsFKApPy8P8vACjpJRDoGGMfEzhFC0ry61ajd7f72J3603anBA==",
+      "version": "21.3.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.2.tgz",
+      "integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
       "license": "MIT",
       "dependencies": {
         "@tokenizer/inflate": "^0.4.1",
@@ -9453,6 +9514,36 @@
       "optional": true,
       "dependencies": {
         "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/fill-range": {
@@ -9540,7 +9631,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -9599,6 +9692,37 @@
       "peerDependencies": {
         "typescript": ">3.6.0",
         "webpack": "^5.11.0"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/fork-ts-checker-webpack-plugin/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/form-data": {
@@ -9970,6 +10094,8 @@
     },
     "node_modules/htmlnano": {
       "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/htmlnano/-/htmlnano-2.1.5.tgz",
+      "integrity": "sha512-IXffzXq1beGQN2rsr03aIPK/rVU1jR2uwHymlAIEf97Tl5WdpG50IsQ5nWGvSGQJ+x6U7S6yac9rRiFgAg4/xQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10015,7 +10141,9 @@
       }
     },
     "node_modules/htmlnano/node_modules/cosmiconfig": {
-      "version": "9.0.0",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+      "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10203,6 +10331,7 @@
     "node_modules/ioredis": {
       "version": "5.10.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -10245,6 +10374,8 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10356,6 +10487,8 @@
     },
     "node_modules/is-json": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-json/-/is-json-2.0.1.tgz",
+      "integrity": "sha512-6BEnpVn1rcf3ngfmViLM6vjUjGErbdrL4rwlv+u1NO1XO8kqT4YGL8+19Q+Z/bas8tY90BTWMk2+fW1g6hQjbA==",
       "license": "ISC",
       "optional": true
     },
@@ -10550,6 +10683,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -11330,6 +11464,8 @@
     },
     "node_modules/juice": {
       "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/juice/-/juice-11.1.1.tgz",
+      "integrity": "sha512-4SBfZqKcc6DrIS+5b/WiGoWaZsdUPBH+e6SbRlNjJpaIRtfoBhYReAtobIEW6mcLeFFDXLBJMuZwkJLkBJjs2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11349,6 +11485,8 @@
     },
     "node_modules/juice/node_modules/commander": {
       "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -11357,6 +11495,8 @@
     },
     "node_modules/juice/node_modules/entities": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "optional": true,
       "engines": {
@@ -11733,6 +11873,8 @@
     },
     "node_modules/mensch": {
       "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/mensch/-/mensch-0.3.4.tgz",
+      "integrity": "sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g==",
       "license": "MIT",
       "optional": true
     },
@@ -11859,62 +12001,74 @@
       }
     },
     "node_modules/mjml": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml/-/mjml-5.0.0-beta.1.tgz",
+      "integrity": "sha512-PpeIXJJnvtuWa7eUntnBBS+i2DCKWvbzpBSc7XDEoToZym5BKi9nZRtaKk9LrWYAfXr8vrYEgGeg1AH37NGxIQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "mjml-cli": "5.0.0-alpha.11",
-        "mjml-core": "5.0.0-alpha.11",
-        "mjml-preset-core": "5.0.0-alpha.11",
-        "mjml-validator": "5.0.0-alpha.11"
+        "mjml-cli": "5.0.0-beta.1",
+        "mjml-core": "5.0.0-beta.1",
+        "mjml-preset-core": "5.0.0-beta.1",
+        "mjml-validator": "5.0.0-beta.1"
       },
       "bin": {
         "mjml": "bin/mjml"
       }
     },
     "node_modules/mjml-accordion": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-accordion/-/mjml-accordion-5.0.0-beta.1.tgz",
+      "integrity": "sha512-TjwTIhtTP34szVfJk09ezcWZ4SY+STC0y+DacoE5HGz0GrzpOqloloepewcfPOWnwvBL8r73HTc/Di8BfuDNIg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-body": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-body/-/mjml-body-5.0.0-beta.1.tgz",
+      "integrity": "sha512-DRp602BJtyydqsxc0S6PWnL4jEmfjFJhK7eopkl0cuxrvAqrF5R1nxu0wDv9gl+rlGQkngZSwAwj31qbLF321w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-button": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-button/-/mjml-button-5.0.0-beta.1.tgz",
+      "integrity": "sha512-nU5xYkXGALRwCjKKLHP5iirchhZwCinU9aPcECd9Z5nSf5CUWzYfjAAJMiVSh3dJkP8Ku4KGCHOMid+gQI8fag==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-carousel": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-carousel/-/mjml-carousel-5.0.0-beta.1.tgz",
+      "integrity": "sha512-EOUey+68l2lwsUHqnBxHqK0HCxeP0QMFZL8TlWHVloQRlOz2ARBqZRW4YiPCQ346/9ixhbrWaag521UBjn0j2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-cli": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-cli/-/mjml-cli-5.0.0-beta.1.tgz",
+      "integrity": "sha512-suZinCikR8E6Oqqgt+Mm8Pk8qterjAW/UEWWqKdrS3sx5qlf6d1ImBx9mY4kYa6OsvrfiJQCr4ffmSLFkKbZLw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11923,18 +12077,37 @@
         "glob": "^10.5.0",
         "lodash": "^4.17.21",
         "minimatch": "^9.0.3",
-        "mjml-core": "5.0.0-alpha.11",
-        "mjml-parser-xml": "5.0.0-alpha.11",
-        "mjml-preset-core": "5.0.0-alpha.11",
-        "mjml-validator": "5.0.0-alpha.11",
+        "mjml-core": "5.0.0-beta.1",
+        "mjml-parser-xml": "5.0.0-beta.1",
+        "mjml-preset-core": "5.0.0-beta.1",
+        "mjml-validator": "5.0.0-beta.1",
         "yargs": "^17.7.2"
       },
       "bin": {
         "mjml-cli": "bin/mjml"
       }
     },
+    "node_modules/mjml-cli/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/mjml-cli/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/mjml-cli/node_modules/chokidar": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11958,6 +12131,8 @@
     },
     "node_modules/mjml-cli/node_modules/glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -11967,8 +12142,26 @@
         "node": ">= 6"
       }
     },
+    "node_modules/mjml-cli/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/mjml-cli/node_modules/picomatch": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -11980,6 +12173,8 @@
     },
     "node_modules/mjml-cli/node_modules/readdirp": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11990,17 +12185,21 @@
       }
     },
     "node_modules/mjml-column": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-column/-/mjml-column-5.0.0-beta.1.tgz",
+      "integrity": "sha512-cpQ8ZGN3i53uTqrUC0K50M7Q/03C9ZJKS9ri/2sp5VKTlLP9HFfartliDNm9rfQSlHyY5injmSNSg846GjbP4Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-core": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-core/-/mjml-core-5.0.0-beta.1.tgz",
+      "integrity": "sha512-5kB9L6EnJnMpQ31jInBBUwG7NWEcBnFzhk+vUqoS6j7i13W1sGbRkVlb1qhzesoTXoghrXUWzWLzUQzDRa9klw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12012,144 +12211,172 @@
         "htmlnano": "^2.1.1",
         "juice": "^11.0.0",
         "lodash": "^4.17.21",
-        "mjml-parser-xml": "5.0.0-alpha.11",
-        "mjml-validator": "5.0.0-alpha.11",
+        "mjml-parser-xml": "5.0.0-beta.1",
+        "mjml-validator": "5.0.0-beta.1",
         "postcss": "^8.5.3",
         "prettier": "^3.5.1"
       }
     },
     "node_modules/mjml-divider": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-divider/-/mjml-divider-5.0.0-beta.1.tgz",
+      "integrity": "sha512-6eY2uyQFRqOQEUpHk9PL14wCcYtvHbaZEjobZ6Ra00gWfopB67BKIRLOLhzXbr3ow/HdTx8/GC4qu6z+dZf6tg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-group": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-group/-/mjml-group-5.0.0-beta.1.tgz",
+      "integrity": "sha512-nwSy2DNEaPfCD5GoiJ/8Us4lg4lYou6DoLhOtvZBrBK/O54uDqZvmQ6L/8UE0222N+4sVBsyp51e+hf5dulp/A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-head": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-head/-/mjml-head-5.0.0-beta.1.tgz",
+      "integrity": "sha512-tRmaJLnNVo0E1UipBgs/5HQwDIC4wWHNZLpnK0gQTy4gNPOeVp93IJhrci6LrDKHxJ2gggtknYMkYdjgvOmwzg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-head-attributes": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-head-attributes/-/mjml-head-attributes-5.0.0-beta.1.tgz",
+      "integrity": "sha512-C2XeN0eocIWuBkl5qvjiyIuua0Y8OkTrdHMRW1M5w+rZhRwqVL9UEKA1KZLi0uBK10XUFSxOVtSHjrBX/zuq2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-head-breakpoint": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-head-breakpoint/-/mjml-head-breakpoint-5.0.0-beta.1.tgz",
+      "integrity": "sha512-rESlOUGyJJLsgwinFN7RkLAlchBGVT/V2PvgfbPbgVZrcIjuV/8xMO+GKTxbpWbdUlSYhnnZGdUWcsxiw0vQ2g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-head-font": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-head-font/-/mjml-head-font-5.0.0-beta.1.tgz",
+      "integrity": "sha512-jWvSYwVAcWbMg3iU5co8s3vfGx6NQwx4+3zfUe/GRpBbqjAcgtc4M7RRYze4NXDLskKIf4ccNWzj9Qhm4hxuqQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-head-html-attributes": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-head-html-attributes/-/mjml-head-html-attributes-5.0.0-beta.1.tgz",
+      "integrity": "sha512-B0UeXBMzHLjnoDBh6ybs3CTc1ajELVrKGcbhQbqzQXMz0IYhpVlOb+qbT7Y8+pltRUChb027C3ZBBZGX0TU/ng==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-head-preview": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-head-preview/-/mjml-head-preview-5.0.0-beta.1.tgz",
+      "integrity": "sha512-cKwmBcTLHWYdjnKqdToIN5rqMY3ukT6uCAlvfvIb7gkXZ1dpQ0youPezBMSfr04Eop7DjltRUhUlHXwI3M7qGw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-head-style": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-head-style/-/mjml-head-style-5.0.0-beta.1.tgz",
+      "integrity": "sha512-kNkBhgmGJSXk6bC5vymd6NOQKU7Ew0BGLuUXdYKMjsSnUYZPVTGTt5CcXLP0DomRSDeLsDQrQ6alnORQfrO2Jg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-head-title": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-head-title/-/mjml-head-title-5.0.0-beta.1.tgz",
+      "integrity": "sha512-MYBk4Bwb5uyBt/jYFBkxCF95EzsL2FDCnfRrtvHOJwxenF0AaXqUiZoRkE0wnukl10P/KHjTXg9xTAo4VykWfg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-hero": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-hero/-/mjml-hero-5.0.0-beta.1.tgz",
+      "integrity": "sha512-Qi5BhyeWWhfkocXB6Gv9HWKbcGlyy0uBKPSU41ujhpuQhZdI8y43GTyHUUaZhdbfkCuPVT3tsV9IIujP0ksWWw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-image": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-image/-/mjml-image-5.0.0-beta.1.tgz",
+      "integrity": "sha512-zzWBBuZIj6Vo+MlwrHVq4pSPMQ40yZSdtkrJPMPUUIT82fjKCzxKQTQCIFRjsb3M5UyPi7Pt9oN7XqPND+b/TQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-navbar": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-navbar/-/mjml-navbar-5.0.0-beta.1.tgz",
+      "integrity": "sha512-ELfxcbc7pICKEKSAncfC6bV1m7c2As+ErBSBIDS470odZHDz25ELfjeiBeCYfRZ1vb+6AJeKKzUjzkxfiNM23g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-parser-xml": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-parser-xml/-/mjml-parser-xml-5.0.0-beta.1.tgz",
+      "integrity": "sha512-Ibn4NBxwxeRqQgs4K06Uk3F/YFQcLqF6xH6MvMSAO8hRos7xjMr/frm7N+co3x1FBFcCytf1Q+sKF5XtPN8i+w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12161,6 +12388,8 @@
     },
     "node_modules/mjml-parser-xml/node_modules/htmlparser2": {
       "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -12178,100 +12407,116 @@
       }
     },
     "node_modules/mjml-preset-core": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-preset-core/-/mjml-preset-core-5.0.0-beta.1.tgz",
+      "integrity": "sha512-ohdebzChWAMQbUZlQsKGFAKMxMobq2x5KSE0kYFQv0zEPqIJzNn0eNcLZ8ztW422orS63U1s3Om+vY3x7r8Nlg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "mjml-accordion": "5.0.0-alpha.11",
-        "mjml-body": "5.0.0-alpha.11",
-        "mjml-button": "5.0.0-alpha.11",
-        "mjml-carousel": "5.0.0-alpha.11",
-        "mjml-column": "5.0.0-alpha.11",
-        "mjml-divider": "5.0.0-alpha.11",
-        "mjml-group": "5.0.0-alpha.11",
-        "mjml-head": "5.0.0-alpha.11",
-        "mjml-head-attributes": "5.0.0-alpha.11",
-        "mjml-head-breakpoint": "5.0.0-alpha.11",
-        "mjml-head-font": "5.0.0-alpha.11",
-        "mjml-head-html-attributes": "5.0.0-alpha.11",
-        "mjml-head-preview": "5.0.0-alpha.11",
-        "mjml-head-style": "5.0.0-alpha.11",
-        "mjml-head-title": "5.0.0-alpha.11",
-        "mjml-hero": "5.0.0-alpha.11",
-        "mjml-image": "5.0.0-alpha.11",
-        "mjml-navbar": "5.0.0-alpha.11",
-        "mjml-raw": "5.0.0-alpha.11",
-        "mjml-section": "5.0.0-alpha.11",
-        "mjml-social": "5.0.0-alpha.11",
-        "mjml-spacer": "5.0.0-alpha.11",
-        "mjml-table": "5.0.0-alpha.11",
-        "mjml-text": "5.0.0-alpha.11",
-        "mjml-wrapper": "5.0.0-alpha.11"
+        "mjml-accordion": "5.0.0-beta.1",
+        "mjml-body": "5.0.0-beta.1",
+        "mjml-button": "5.0.0-beta.1",
+        "mjml-carousel": "5.0.0-beta.1",
+        "mjml-column": "5.0.0-beta.1",
+        "mjml-divider": "5.0.0-beta.1",
+        "mjml-group": "5.0.0-beta.1",
+        "mjml-head": "5.0.0-beta.1",
+        "mjml-head-attributes": "5.0.0-beta.1",
+        "mjml-head-breakpoint": "5.0.0-beta.1",
+        "mjml-head-font": "5.0.0-beta.1",
+        "mjml-head-html-attributes": "5.0.0-beta.1",
+        "mjml-head-preview": "5.0.0-beta.1",
+        "mjml-head-style": "5.0.0-beta.1",
+        "mjml-head-title": "5.0.0-beta.1",
+        "mjml-hero": "5.0.0-beta.1",
+        "mjml-image": "5.0.0-beta.1",
+        "mjml-navbar": "5.0.0-beta.1",
+        "mjml-raw": "5.0.0-beta.1",
+        "mjml-section": "5.0.0-beta.1",
+        "mjml-social": "5.0.0-beta.1",
+        "mjml-spacer": "5.0.0-beta.1",
+        "mjml-table": "5.0.0-beta.1",
+        "mjml-text": "5.0.0-beta.1",
+        "mjml-wrapper": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-raw": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-raw/-/mjml-raw-5.0.0-beta.1.tgz",
+      "integrity": "sha512-RjckRM3SCQAjXF0FP0Kyodju443N5Kl7FnDh4Jw1abJn5fskKqVThMt/NyZHzhR+DX3G/2nR0Oq1qMSTHTUIHw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-section": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-section/-/mjml-section-5.0.0-beta.1.tgz",
+      "integrity": "sha512-9X1VIHGGNSdzYjvOWR/FeeKvw/JViD1Wo8WyBz0hUPXagv2dI7S5MqL2Jr3sRY11ztz6VGjlR3wxqw0E0GwI5A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-social": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-social/-/mjml-social-5.0.0-beta.1.tgz",
+      "integrity": "sha512-T4e5QtPWuRomMwePvsrXN1zijyXII3q44vZUlY5OgviFDeTE6dWYFWHHCMtWRRRtidNuoQ5ri4R1Eqe5oitYag==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-spacer": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-spacer/-/mjml-spacer-5.0.0-beta.1.tgz",
+      "integrity": "sha512-OJEGMXIotDiTLawPlZVcqc/H2ryYarfsvfwQNPxfaARBClrW+07usRjF9eSgBj0zxIT2rplfTMXYW/xrH3C/HQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-table": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-table/-/mjml-table-5.0.0-beta.1.tgz",
+      "integrity": "sha512-9k0DBTGMi4WBVkqTSBiftsNCJr5ENIZ1XjpbFCoXe00Q4V5kxPhS2Rkdk0WT2S/Olrbwmdyj4GZpJo5sphWFqg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-text": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-text/-/mjml-text-5.0.0-beta.1.tgz",
+      "integrity": "sha512-yZGKYj/eMJLLWhLg7QPjCbwJkG03gz/Fy+px3a5Kz5TdsFQ1dSOR4BJeKjNWWwYdLdHZUlpq7pR11en3mBdoUA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1"
       }
     },
     "node_modules/mjml-validator": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-validator/-/mjml-validator-5.0.0-beta.1.tgz",
+      "integrity": "sha512-JH4k6ZKk6kuKa+fS16aoBLDXdSGRLMCv5LczQGKWVH7X7YgmasPv8SYyr0FMALJo77Y6wsIS1951KclCEEEcrQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12279,14 +12524,16 @@
       }
     },
     "node_modules/mjml-wrapper": {
-      "version": "5.0.0-alpha.11",
+      "version": "5.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mjml-wrapper/-/mjml-wrapper-5.0.0-beta.1.tgz",
+      "integrity": "sha512-rI+MEMzHBUyzijguBZOjOu2SeG3/M2AYdxGOH3cpUSFRXnV5dTkdLn3liO86HBS9YsimWkJGreA5hML6QlJZ+A==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "lodash": "^4.17.21",
-        "mjml-core": "5.0.0-alpha.11",
-        "mjml-section": "5.0.0-alpha.11"
+        "mjml-core": "5.0.0-beta.1",
+        "mjml-section": "5.0.0-beta.1"
       }
     },
     "node_modules/module-details-from-path": {
@@ -12463,6 +12710,7 @@
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.2.tgz",
       "integrity": "sha512-zbj002pZAIkWQFxyAaqoxvn+zoIwRnS40hgjqTXudKOOJkiFFgBeNqjgD3/YCR12sZnrghWYBY+yP1ZucdDRpw==",
       "license": "MIT-0",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -12490,6 +12738,8 @@
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
       "devOptional": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -12729,6 +12979,8 @@
     },
     "node_modules/parse5": {
       "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12740,6 +12992,8 @@
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12752,6 +13006,8 @@
     },
     "node_modules/parse5-parser-stream": {
       "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -12763,6 +13019,8 @@
     },
     "node_modules/parse5/node_modules/entities": {
       "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "license": "BSD-2-Clause",
       "optional": true,
       "engines": {
@@ -12793,6 +13051,7 @@
     "node_modules/passport": {
       "version": "0.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -12916,6 +13175,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -13118,6 +13378,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13611,6 +13872,8 @@
     },
     "node_modules/posthtml": {
       "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/posthtml/-/posthtml-0.16.7.tgz",
+      "integrity": "sha512-7Hc+IvlQ7hlaIfQFZnxlRl0jnpWq2qwibORBhQYIb0QbNtuicc5ZxvKkVT71HJ4Py1wSZ/3VR1r8LfkCtoCzhw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13623,6 +13886,8 @@
     },
     "node_modules/posthtml-parser": {
       "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/posthtml-parser/-/posthtml-parser-0.11.0.tgz",
+      "integrity": "sha512-QecJtfLekJbWVo/dMAA+OSwY79wpRmbqS5TeXvXSX+f0c6pW4/SE6inzZ2qkU7oAMCPqIDkZDvd/bQsSFUnKyw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13634,6 +13899,8 @@
     },
     "node_modules/posthtml-parser/node_modules/dom-serializer": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13647,6 +13914,8 @@
     },
     "node_modules/posthtml-parser/node_modules/dom-serializer/node_modules/entities": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
       "license": "BSD-2-Clause",
       "optional": true,
       "funding": {
@@ -13655,6 +13924,8 @@
     },
     "node_modules/posthtml-parser/node_modules/domhandler": {
       "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
       "license": "BSD-2-Clause",
       "optional": true,
       "dependencies": {
@@ -13669,6 +13940,8 @@
     },
     "node_modules/posthtml-parser/node_modules/domutils": {
       "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
       "license": "BSD-2-Clause",
       "optional": true,
       "dependencies": {
@@ -13682,6 +13955,8 @@
     },
     "node_modules/posthtml-parser/node_modules/entities": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
       "license": "BSD-2-Clause",
       "optional": true,
       "engines": {
@@ -13693,6 +13968,8 @@
     },
     "node_modules/posthtml-parser/node_modules/htmlparser2": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -13711,6 +13988,8 @@
     },
     "node_modules/posthtml-render": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/posthtml-render/-/posthtml-render-3.0.0.tgz",
+      "integrity": "sha512-z+16RoxK3fUPgwaIgH9NGnK1HKY9XIDpydky5eQGgAFVXTCSezalv9U2jQuNV+Z9qV1fDWNzldcw4eK0SSbqKA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -13732,6 +14011,7 @@
       "version": "3.8.1",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14155,7 +14435,8 @@
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -14435,6 +14716,7 @@
     "node_modules/rxjs": {
       "version": "7.8.2",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -14702,6 +14984,8 @@
     },
     "node_modules/slick": {
       "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/slick/-/slick-1.12.2.tgz",
+      "integrity": "sha512-4qdtOGcBjral6YIBCWJ0ljFSKNLz9KkhbWtuGvUyRowl1kxfuE1x/Z/aJcaiilpb3do9bl5K7/1h9XC5wWpY/A==",
       "license": "MIT (http://mootools.net/license.txt)",
       "optional": true,
       "engines": {
@@ -14986,6 +15270,7 @@
       "version": "4.0.1",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "commander": "^11.1.0",
         "css-select": "^5.1.0",
@@ -15079,6 +15364,7 @@
       "version": "5.44.1",
       "devOptional": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -15397,6 +15683,7 @@
       "version": "10.9.2",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15594,6 +15881,7 @@
     "node_modules/typeorm": {
       "version": "0.3.28",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -15738,6 +16026,7 @@
       "version": "5.9.3",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15753,6 +16042,7 @@
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
+      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -15790,9 +16080,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.24.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
-      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -15949,6 +16239,8 @@
     },
     "node_modules/valid-data-url": {
       "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/valid-data-url/-/valid-data-url-3.0.1.tgz",
+      "integrity": "sha512-jOWVmzVceKlVVdwjNSenT4PbGghU0SBIizAev8ofZVgivk/TVHXSbNL8LP6M3spZvkR9/QolkyJavGSX5Cs0UA==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -16012,6 +16304,8 @@
     },
     "node_modules/web-resource-inliner": {
       "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/web-resource-inliner/-/web-resource-inliner-8.0.0.tgz",
+      "integrity": "sha512-Ezr98sqXW/+OCGoUEXuOKVR+oVFlSdn1tIySEEJdiSAw4IjrW8hQkwARSSBJTSB5Us5dnytDgL0ZDliAYBhaNA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16027,6 +16321,8 @@
     },
     "node_modules/web-resource-inliner/node_modules/htmlparser2": {
       "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-9.1.0.tgz",
+      "integrity": "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -16047,6 +16343,7 @@
       "version": "5.104.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -16181,6 +16478,9 @@
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16192,6 +16492,8 @@
     },
     "node_modules/whatwg-encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16203,6 +16505,8 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "license": "MIT",
       "optional": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@aws-sdk/client-s3": "^3.1008.0",
+    "@aws-sdk/client-s3": "^3.1009.0",
     "@aws-sdk/client-secrets-manager": "^3.1009.0",
-    "@aws-sdk/client-sesv2": "^3.1008.0",
+    "@aws-sdk/client-sesv2": "^3.1009.0",
     "@nestjs-modules/mailer": "^2.0.2",
     "@nestjs/common": "^11.1.16",
     "@nestjs/config": "^4.0.3",
@@ -141,17 +141,17 @@
     "typescript": "^5.5.3"
   },
   "overrides": {
-    "file-type": "^21.3.1",
+    "file-type": "^21.3.2",
+    "flatted": "^3.4.1",
     "ajv": "^8.18.0",
     "svgo": "^4.0.1",
     "eslint": {
       "ajv": "^6.14.0"
     },
-    "minimatch": "^10.2.4",
     "test-exclude": "^8.0.0",
     "glob": "^13.0.0",
     "fast-xml-parser": "^5.4.1",
-    "mjml": "^5.0.0-alpha.11",
+    "mjml": "^5.0.0-beta.1",
     "serialize-javascript": "^7.0.3",
     "underscore": "^1.13.8"
   },


### PR DESCRIPTION
## Description

This pull request enhances project security by updating existing dependency overrides, introducing a new override for a critical vulnerability, and removing a redundant override. These changes are reflected in the updated security documentation to provide clear guidance and context.

Specifically, the following modifications have been made:
-   **`file-type`**: The override is updated to `^21.3.2` to address a new ZIP decompression bomb DoS vulnerability (`GHSA-j47w-4g3g-c36v`). The documentation has been adjusted to reference the new patched version and vulnerability.
-   **`flatted`**: A new override `^3.4.1` is introduced to mitigate an unbounded recursion DoS vulnerability (`GHSA-25h7-pfq9-p65f`) which was affecting ESLint's cache chain. This new override and its rationale are thoroughly documented.
-   **`minimatch`**: The top-level override for `minimatch` has been removed. This is because the dependency tree now natively resolves to a secure version (`10.2.4`), rendering the override unnecessary. This removal is documented accordingly.
-   **`mjml`**: The version override is updated to `^5.0.0-beta.1` from `^5.0.0-alpha.11` to align with the latest prerelease, which is required for compatibility with the email template rendering pipeline.
-   AWS SDK client dependencies (`@aws-sdk/client-s3`, `@aws-sdk/client-sesv2`) are updated to `^3.1009.0`.
-   The `package-lock.json` file is refreshed to incorporate these and other transitive dependency updates, including various `@smithy` packages and `undici`.

## Type of Change

-   [ ] New feature
-   [x] Bug fix
-   [x] Documentation update
-   [ ] Refactoring
-   [ ] Breaking change (explain below)

## Checklist

-   [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
-   [ ] I have added/updated tests to cover my changes.
-   [x] I have updated the documentation where necessary.
-   [x] I have considered the security implications of these changes.
-   [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

The updates for `file-type` and `flatted` directly address high-severity vulnerabilities in transitive dependencies that could not be resolved by `npm audit fix --force` without introducing breaking changes to primary dependencies (e.g., `@nestjs/common` for `file-type`, ESLint for `flatted`). The removal of the `minimatch` override cleans up a now-redundant entry. No breaking changes are anticipated from these updates.

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>