### PR TITLE
fix(migration): Ensures faction icon updates apply

### DIFF
--- a/src/database/migrations/1774318826026-AccountAndCharacterUpdates.ts
+++ b/src/database/migrations/1774318826026-AccountAndCharacterUpdates.ts
@@ -13,37 +13,31 @@ export class AccountAndCharacterUpdates1774318826026 implements MigrationInterfa
       UPDATE "sto_info_app"."character_faction" 
       SET "iconUrl" = 'https://cdn.startrekonline.info/cdn-cgi/imagedelivery/jQ0uSdJ3ty-KasNpXGxyuA/a69420ff-952f-4776-ebed-ffcbfd634500/square100' 
       WHERE "name" = 'Klingon Defense Force' 
-      ON CONFLICT DO NOTHING;
     `);
     await queryRunner.query(`
       UPDATE "sto_info_app"."character_faction" 
       SET "iconUrl" = 'https://cdn.startrekonline.info/cdn-cgi/imagedelivery/jQ0uSdJ3ty-KasNpXGxyuA/1f195b7b-301a-47b1-02a9-d52a2fb35800/square100' 
       WHERE "name" = 'Dominion' 
-      ON CONFLICT DO NOTHING;
     `);
     await queryRunner.query(`
       UPDATE "sto_info_app"."character_faction" 
       SET "iconUrl" = 'https://cdn.startrekonline.info/cdn-cgi/imagedelivery/jQ0uSdJ3ty-KasNpXGxyuA/e8246159-ea6a-46bf-a756-efac4e9d5f00/square100' 
       WHERE "name" = 'Discovery Starfleet' 
-      ON CONFLICT DO NOTHING;
     `);
     await queryRunner.query(`
       UPDATE "sto_info_app"."character_faction" 
       SET "iconUrl" = 'https://cdn.startrekonline.info/cdn-cgi/imagedelivery/jQ0uSdJ3ty-KasNpXGxyuA/276a6f60-18d0-457f-dfa5-f2041fd26200/square100' 
       WHERE "name" = 'Starfleet (2409)' 
-      ON CONFLICT DO NOTHING;
     `);
     await queryRunner.query(`
       UPDATE "sto_info_app"."character_faction" 
       SET "iconUrl" = 'https://cdn.startrekonline.info/cdn-cgi/imagedelivery/jQ0uSdJ3ty-KasNpXGxyuA/aed972bf-8e47-4b85-35a0-31dacdb66300/square100' 
       WHERE "name" = 'Romulan Republic' 
-      ON CONFLICT DO NOTHING;
     `);
     await queryRunner.query(`
       UPDATE "sto_info_app"."character_faction" 
       SET "iconUrl" = 'https://cdn.startrekonline.info/cdn-cgi/imagedelivery/jQ0uSdJ3ty-KasNpXGxyuA/d3f36f5b-e84c-40bf-6897-29f174a1aa00/square100' 
       WHERE "name" = 'TOS Starfleet' 
-      ON CONFLICT DO NOTHING;
     `);
 
     // Update faction allegiance icons


### PR DESCRIPTION
## Description

Removes the `ON CONFLICT DO NOTHING` clause from `UPDATE` statements within the character faction icon migration. This clause was incorrectly applied to `UPDATE` statements and could prevent the `iconUrl` fields from being properly updated, leading to missing faction icons for captains. Removing it ensures the updates execute as intended, correcting the display of these icons.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation where necessary.
- [ ] I have considered the security implications of these changes.
- [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

This change addresses issue SC-998, where recruit icons were missing from the captain's view due to the migration failing to correctly update faction icon URLs.

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>