### PR TITLE
fix(icons): update character recruit type icon URLs

### DIFF
--- a/src/database/migrations/1774318826026-AccountAndCharacterUpdates.ts
+++ b/src/database/migrations/1774318826026-AccountAndCharacterUpdates.ts
@@ -43,22 +43,22 @@ export class AccountAndCharacterUpdates1774318826026 implements MigrationInterfa
     // Update faction allegiance icons
     await queryRunner.query(`
       UPDATE "sto_info_app"."character_recruit_type" 
-      SET "iconUrl" = 'https://imagedelivery.net/jQ0uSdJ3ty-KasNpXGxyuA/22af6120-b106-4c84-6c7b-8de08aa0b100/square40' 
+      SET "iconUrl" = 'https://cdn.startrekonline.info/cdn-cgi/imagedelivery/jQ0uSdJ3ty-KasNpXGxyuA/22af6120-b106-4c84-6c7b-8de08aa0b100/square40' 
       WHERE "name" = 'Klingon'
     `);
     await queryRunner.query(`
       UPDATE "sto_info_app"."character_recruit_type" 
-      SET "iconUrl" = 'https://imagedelivery.net/jQ0uSdJ3ty-KasNpXGxyuA/40106e2c-b42a-4d63-0164-a432286b8e00/square40' 
+      SET "iconUrl" = 'https://cdn.startrekonline.info/cdn-cgi/imagedelivery/jQ0uSdJ3ty-KasNpXGxyuA/40106e2c-b42a-4d63-0164-a432286b8e00/square40' 
       WHERE "name" = 'Gamma'
     `);
     await queryRunner.query(`
       UPDATE "sto_info_app"."character_recruit_type" 
-      SET "iconUrl" = 'https://imagedelivery.net/jQ0uSdJ3ty-KasNpXGxyuA/96164c2e-a624-4c11-ce89-26f401e76700/square40' 
+      SET "iconUrl" = 'https://cdn.startrekonline.info/cdn-cgi/imagedelivery/jQ0uSdJ3ty-KasNpXGxyuA/96164c2e-a624-4c11-ce89-26f401e76700/square40' 
       WHERE "name" = 'Temporal'
     `);
     await queryRunner.query(`
       UPDATE "sto_info_app"."character_recruit_type" 
-      SET "iconUrl" = 'https://imagedelivery.net/jQ0uSdJ3ty-KasNpXGxyuA/9641d7f7-c37b-4ab8-c5d9-4c09e2ee3300/square40' 
+      SET "iconUrl" = 'https://cdn.startrekonline.info/cdn-cgi/imagedelivery/jQ0uSdJ3ty-KasNpXGxyuA/9641d7f7-c37b-4ab8-c5d9-4c09e2ee3300/square40' 
       WHERE "name" = 'Delta'
     `);
   }


### PR DESCRIPTION
## Description

Updates the icon URLs for various character recruit types (Klingon, Gamma, Temporal, Delta) within the database migration. This resolves an issue where these icons were not displaying correctly due to referencing an incorrect CDN. The URLs have been corrected to use the appropriate `cdn.startrekonline.info` domain.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [X] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation where necessary.
- [ ] I have considered the security implications of these changes.
- [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

Fixes SC-998

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>