### PR TITLE
fix(deps): Update lodash and resolve NestJS peer conflict

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -21,7 +21,7 @@ Current overrides in `package.json`:
 ```json
 "overrides": {
   "file-type": "^21.3.3",
-  "flatted": "^3.4.2",
+  "lodash": "^4.18.1",
   "ajv": "^8.18.0",
   "eslint": {
     "ajv": "^6.14.0"
@@ -57,6 +57,21 @@ Current overrides in `package.json`:
 npm view @nestjs/common@latest dependencies.file-type
 ```
 
+#### `lodash`
+
+- **Vulnerabilities**:
+  - [GHSA-r5fr-rjxr-66jc](https://github.com/advisories/GHSA-r5fr-rjxr-66jc) — Code Injection via `_.template` imports key names in `lodash <= 4.17.23`. CVSS High.
+  - [GHSA-f23m-r3pf-42rh](https://github.com/advisories/GHSA-f23m-r3pf-42rh) — Prototype Pollution via array path bypass in `_.unset` and `_.omit` in `lodash <= 4.17.23`. CVSS High.
+- **Root cause**: `@nestjs/config` and `@nestjs/swagger` both depend on `lodash@4.17.23`. `npm audit fix --force` would downgrade `@nestjs/config` to `1.1.5`, which is a breaking change.
+- **Override**: `"lodash": "^4.18.1"` — forces the patched release (4.18.0+ fixes both advisories) across the entire tree.
+
+**When it can be removed**: When `@nestjs/config` and `@nestjs/swagger` update their own `lodash` dependency to `>= 4.17.24` natively, or stop depending on lodash. Verify by removing the override and running `npm audit --omit=dev --audit-level=high`. Check with:
+
+```sh
+npm view @nestjs/config@latest dependencies.lodash
+npm view @nestjs/swagger@latest dependencies.lodash
+```
+
 #### `multer` (nested under `@nestjs/platform-express`) — **removed from overrides**
 
 - **Vulnerability**: [GHSA-5528-5vmv-3xc2](https://github.com/advisories/GHSA-5528-5vmv-3xc2) — Denial of Service via uncontrolled recursion in `multer < 2.1.1`.
@@ -76,13 +91,10 @@ npm view @nestjs/platform-express@latest dependencies.multer
 
 **When it can be removed**: When ESLint no longer depends on `ajv@6` internals and lint passes without the nested override.
 
-#### `flatted`
+#### `flatted` — **removed from overrides**
 
 - **Vulnerability**: [GHSA-25h7-pfq9-p65f](https://github.com/advisories/GHSA-25h7-pfq9-p65f) — unbounded recursion DoS in `flatted < 3.4.0`.
-- **Root cause**: ESLint's cache chain (`eslint -> file-entry-cache -> flat-cache`) previously resolved to `flatted@3.3.3`.
-- **Override**: `"flatted": "^3.4.2"` — forces a safe release in the full dependency tree.
-
-**When it can be removed**: When all transitive consumers request `flatted >= 3.4.0` natively. Verify by removing the override and running full `npm audit`.
+- **Removed**: `flat-cache@4.0.1` (used by `eslint -> file-entry-cache -> flat-cache`) now requests `flatted@^3.2.9`, which npm resolves naturally to `3.4.2` — the latest 3.x release and the first safe version. The override is redundant.
 
 #### `svgo` — **removed from overrides**
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -41,6 +41,9 @@ Current overrides in `package.json`:
   },
   "micromatch": {
     "picomatch": "^2.3.2"
+  },
+  "@nestjs/swagger": {
+    "@nestjs/mapped-types": "^2.1.1"
   }
 }
 ```
@@ -128,6 +131,8 @@ npm view @nestjs/platform-express@latest dependencies.multer
 
 **When it can be removed**: When `@nestjs-modules/mailer` officially supports and requests `mjml@^5` in its own dependencies, or when the project migrates away from mjml.
 
+> **Note**: `mjml-core` (pulled in transitively by this override) has a known unfixed directory traversal vulnerability (CVE-2025-67898). See the `mjml-core` section below for the risk assessment and monitoring instructions.
+
 #### `serialize-javascript`
 
 - **Root cause**: `terser-webpack-plugin` requests `serialize-javascript@^6`, which has known vulnerabilities.
@@ -205,6 +210,30 @@ npm view jest-haste-map@latest dependencies.picomatch
 ```sh
 npm view fork-ts-checker-webpack-plugin@latest dependencies.minimatch
 npm view mjml-cli@latest dependencies.minimatch
+```
+
+#### `@nestjs/swagger` → `@nestjs/mapped-types`
+
+- **Root cause**: `@nestjs/swagger@11.2.6` bundles `@nestjs/mapped-types@2.1.0` as a nested dependency. That version declares a `peerOptional` of `class-validator@^0.13.0 || ^0.14.0`, which excludes `0.15.x`. Our root install uses `class-validator@^0.15.1`, causing npm to emit an `ERESOLVE` peer-conflict warning on every `npm install`.
+- **Override**: `"@nestjs/swagger": { "@nestjs/mapped-types": "^2.1.1" }` — forces the nested copy to `2.1.1`, which extends the peer range to include `^0.15.0`, eliminating the warning.
+
+**When it can be removed**: When `@nestjs/swagger` updates its own bundled `@nestjs/mapped-types` to `>= 2.1.1`. Verify with:
+
+```sh
+npm view @nestjs/swagger@latest dependencies.@nestjs/mapped-types
+```
+
+#### `mjml-core` — no override available (known vulnerability, no upstream fix)
+
+- **Vulnerability**: [SNYK-JS-MJMLCORE-14417285](https://security.snyk.io/vuln/SNYK-JS-MJMLCORE-14417285) / CVE-2025-67898 — Directory Traversal via the `ignoreIncludes` parameter in `mjml-core`. CVSS Medium. **Fixed in: Not Fixed** (as of 2026-04-04).
+- **Root cause**: `@nestjs-modules/mailer` depends on `mjml`, which pulls in `mjml-core@5.0.0-beta.2` (forced by the `mjml` override). No patched release exists in any branch.
+- **Risk assessment**: Exploitation requires an attacker to supply crafted input to the `ignoreIncludes` parameter. This project only processes internally authored email templates; no user-controlled content is passed to mjml. Practical exploitation risk is **low**.
+- **No override action**: A version override cannot help because there is no patched release. `npm audit` does not flag this advisory (it is Snyk-specific).
+
+**When it can be remediated**: When a patched `mjml-core` release is published. Monitor [CVE-2025-67898](https://www.cve.org/CVERecord?id=CVE-2025-67898) and the [mjml changelog](https://github.com/mjmlio/mjml/blob/master/CHANGELOG.md) for a fix. Verify with:
+
+```sh
+npm view mjml-core@latest version
 ```
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1173,6 +1173,7 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3262,6 +3263,19 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@nestjs-modules/mailer/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@nestjs-modules/mailer/node_modules/nunjucks": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
@@ -3286,6 +3300,19 @@
         "chokidar": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs-modules/mailer/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/@nestjs/cli": {
@@ -3338,6 +3365,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.18.tgz",
       "integrity": "sha512-0sLq8Z+TIjLnz1Tqp0C/x9BpLbqpt1qEu0VcH4/fkE0y3F5JxhfK1AdKQ/SPbKhKgwqVDoY4gS8GQr2G6ujaWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.4",
         "iterare": "1.2.1",
@@ -3393,6 +3421,7 @@
       "integrity": "sha512-wR3DtGyk/LUAiPtbXDuWJJwVkWElKBY0sqnTzf9d4uM3+X18FRZhK7WFc47czsIGOdWuRsMeLYV+1Z9dO4zDEQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -3452,6 +3481,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.18.tgz",
       "integrity": "sha512-s6GdHMTa3qx0fJewR74Xa30ysPHfBEqxIwZ7BGSTLoAEQ1vTP24urNl+b6+s49NFLEIOyeNho5fN/9/I17QlOw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.6",
         "express": "5.2.1",
@@ -3605,6 +3635,7 @@
     "node_modules/@nestjs/terminus": {
       "version": "11.1.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "boxen": "5.1.2",
         "check-disk-space": "3.4.0"
@@ -3712,6 +3743,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.1.tgz",
       "integrity": "sha512-8rw/nKT0S+L+MkzgE9F2/mox7mAgsPlwfzmW9gsESN1lmQtIrVEfiiBwC2O8+guS1jBfQehJIdcdUj2OAp4VUQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@nestjs/common": "^10.0.0 || ^11.0.0",
         "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -3778,6 +3810,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3799,6 +3832,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.1.tgz",
       "integrity": "sha512-XHzhwRNkBpeP8Fs/qjGrAf9r9PRv67wkJQ/7ZPaBQQ68DYlTBBx5MF9LvPx7mhuXcDessKK2b+DcxqwpgkcivQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -3811,6 +3845,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
       "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -4235,6 +4270,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
       "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4251,6 +4287,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.1.tgz",
       "integrity": "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.6.1",
         "@opentelemetry/resources": "2.6.1",
@@ -4268,6 +4305,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
       "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -5315,6 +5353,7 @@
       "version": "9.6.0",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@inquirer/prompts": "^8.0.0",
         "@stryker-mutator/api": "9.6.0",
@@ -6060,6 +6099,7 @@
       "version": "9.6.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -6210,6 +6250,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -6399,6 +6440,7 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -7043,6 +7085,7 @@
     "node_modules/acorn": {
       "version": "8.16.0",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7095,6 +7138,7 @@
       "version": "8.18.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -7643,6 +7687,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7924,6 +7969,7 @@
       "version": "4.0.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -7962,11 +8008,13 @@
     },
     "node_modules/class-transformer": {
       "version": "0.5.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.15.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -8396,6 +8444,7 @@
       "integrity": "sha512-T9PNS7y+5Nc9Qmu9mRONqfxG1RVY7Vuvky0XN6MZ+9hqplesTEwnj9r0ROtVuSwUVfaDhVlavuzWIVLUgm4hkQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssnano-preset-default": "^7.0.12",
         "lilconfig": "^3.1.3"
@@ -8992,6 +9041,7 @@
       "integrity": "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9046,6 +9096,7 @@
       "version": "10.1.8",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9324,6 +9375,7 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -9367,6 +9419,7 @@
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
       "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "10.1.0"
       },
@@ -10421,6 +10474,7 @@
       "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
       "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ioredis/commands": "1.5.1",
         "cluster-key-slot": "^1.1.0",
@@ -10756,6 +10810,7 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -11730,7 +11785,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.defaults": {
@@ -12715,6 +12772,7 @@
       "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
       "integrity": "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==",
       "license": "MIT-0",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -13055,6 +13113,7 @@
     "node_modules/passport": {
       "version": "0.7.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -13180,6 +13239,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -13384,6 +13444,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14016,6 +14077,7 @@
       "version": "3.8.1",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14441,7 +14503,8 @@
     },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -14723,6 +14786,7 @@
     "node_modules/rxjs": {
       "version": "7.8.2",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -15270,6 +15334,7 @@
       "version": "4.0.1",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "commander": "^11.1.0",
         "css-select": "^5.1.0",
@@ -15365,6 +15430,7 @@
       "version": "5.44.1",
       "devOptional": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -15689,6 +15755,7 @@
       "version": "10.9.2",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -15886,6 +15953,7 @@
     "node_modules/typeorm": {
       "version": "0.3.28",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -16032,6 +16100,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16047,6 +16116,7 @@
     },
     "node_modules/uglify-js": {
       "version": "3.19.3",
+      "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
       "bin": {
@@ -16355,6 +16425,7 @@
       "integrity": "sha512-jTywjboN9aHxFlToqb0K0Zs9SbBoW4zRUlGzI2tYNxVYcEi/IPpn+Xi4ye5jTLvX2YeLuic/IvxNot+Q1jMoOw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3468,6 +3468,26 @@
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
+      "integrity": "sha512-SCCoMEJ6jdeI5h/N+KCVF1+pmg/hmEkNA5nHTS8Gvww7T/LCl4o1gFLinw2iQ60w7slFkszHcGLKGdazVI4F8A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0 || ^0.15.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/passport": {
       "version": "11.0.5",
       "license": "MIT",
@@ -3606,24 +3626,6 @@
         "@fastify/static": {
           "optional": true
         },
-        "class-transformer": {
-          "optional": true
-        },
-        "class-validator": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nestjs/swagger/node_modules/@nestjs/mapped-types": {
-      "version": "2.1.0",
-      "license": "MIT",
-      "peerDependencies": {
-        "@nestjs/common": "^10.0.0 || ^11.0.0",
-        "class-transformer": "^0.4.0 || ^0.5.0",
-        "class-validator": "^0.13.0 || ^0.14.0",
-        "reflect-metadata": "^0.1.12 || ^0.2.0"
-      },
-      "peerDependenciesMeta": {
         "class-transformer": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -162,6 +162,9 @@
     },
     "micromatch": {
       "picomatch": "^2.3.2"
+    },
+    "@nestjs/swagger": {
+      "@nestjs/mapped-types": "^2.1.1"
     }
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
   },
   "overrides": {
     "file-type": "^21.3.3",
-    "flatted": "^3.4.2",
+    "lodash": "^4.18.1",
     "ajv": "^8.18.0",
     "eslint": {
       "ajv": "^6.14.0"


### PR DESCRIPTION
## Description

Updates dependencies and resolves peer dependency conflicts to improve project stability and security:

- **`lodash` update**: Addresses high-severity code injection and prototype pollution vulnerabilities by enforcing `lodash@4.18.1` across the dependency tree. This resolves advisories GHSA-r5fr-rjxr-66jc and GHSA-f23m-r3pf-42rh, which were present due to older `lodash` versions pulled in by `@nestjs/config` and `@nestjs/swagger`.
- **`@nestjs/swagger` peer dependency conflict**: Resolves an `ERESOLVE` peer-conflict warning by overriding `@nestjs/swagger`'s nested `@nestjs/mapped-types` dependency to `2.1.1`. This version extends its `class-validator` peer range to include `0.15.x`, aligning with the project's root `class-validator` version and eliminating the warning.
- **`flatted` override removal**: Removes the redundant `flatted` override from `package.json` and the security documentation. `flat-cache@4.0.1` now naturally resolves to `flatted@3.4.2`, which is a safe version, making the explicit override unnecessary.
- **`mjml-core` vulnerability documentation**: Adds a new section to the security documentation detailing a known, unfixed directory traversal vulnerability (CVE-2025-67898) in `mjml-core`. It includes a risk assessment (deemed low due to internal-only template processing) and instructions for monitoring.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [x] I have updated the documentation where necessary.
- [x] I have considered the security implications of these changes.
- [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

No breaking changes are introduced with these dependency updates.

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>