### PR TITLE
fix(mail): Adjusts SendGrid module imports and types

### DIFF
--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -1,6 +1,7 @@
 import { MailerService } from '@nestjs-modules/mailer';
 import { Injectable, Logger } from '@nestjs/common';
-import * as sgMail from '@sendgrid/mail';
+import sgMail from '@sendgrid/mail';
+import type { MailDataRequired } from '@sendgrid/mail';
 import * as ejs from 'ejs';
 import { convert as htmlToText } from 'html-to-text';
 import * as path from 'node:path';
@@ -300,7 +301,7 @@ export class MailService {
    * @param message - The SendGrid email message to send.
    * @returns A promise that resolves when the email has been sent via SendGrid.
    */
-  async sendEmailViaSendGrid(message: sgMail.MailDataRequired) {
+  async sendEmailViaSendGrid(message: MailDataRequired) {
     try {
       await sgMail.send(message);
     } catch (error) {
@@ -319,7 +320,7 @@ export class MailService {
    * @param message - The internal email message.
    * @returns A SendGrid MailDataRequired object.
    */
-  toSendGridMessage(message: EmailMessage): sgMail.MailDataRequired {
+  toSendGridMessage(message: EmailMessage): MailDataRequired {
     return {
       to: message.to,
       from: message.from,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
     "strict": true,
     "strictPropertyInitialization": false,
     "target": "es2021",


### PR DESCRIPTION
## Description

This change resolves an issue with SendGrid module imports and type compatibility. It enables `esModuleInterop` in `tsconfig.json`, which allows for a more standard default import syntax for `sgMail`. Consequently, the `mail.service.ts` file has been updated to use a default import for the SendGrid package and to explicitly import and utilise the `MailDataRequired` type. This ensures correct module resolution and type consistency, addressing a backend deployment error.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation where necessary.
- [ ] I have considered the security implications of these changes.
- [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

Relates to SC-1018

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>