### PR TITLE
feat: Enforces underscore prefix for readonly class members

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,6 +42,46 @@ export default [
       ...tsPlugin.configs.recommended.rules,
       ...prettierPlugin.configs.recommended.rules,
 
+      '@typescript-eslint/naming-convention': [
+        'error',
+        {
+          selector: 'classProperty',
+          modifiers: ['readonly', 'private', 'static'],
+          format: ['strictCamelCase', 'UPPER_CASE'],
+          leadingUnderscore: 'require',
+        },
+        {
+          selector: 'classProperty',
+          modifiers: ['readonly', 'protected', 'static'],
+          format: ['strictCamelCase', 'UPPER_CASE'],
+          leadingUnderscore: 'require',
+        },
+        {
+          selector: 'classProperty',
+          modifiers: ['readonly', 'private'],
+          format: ['strictCamelCase'],
+          leadingUnderscore: 'require',
+        },
+        {
+          selector: 'classProperty',
+          modifiers: ['readonly', 'protected'],
+          format: ['strictCamelCase'],
+          leadingUnderscore: 'require',
+        },
+        {
+          selector: 'parameterProperty',
+          modifiers: ['readonly', 'private'],
+          format: ['strictCamelCase'],
+          leadingUnderscore: 'require',
+        },
+        {
+          selector: 'parameterProperty',
+          modifiers: ['readonly', 'protected'],
+          format: ['strictCamelCase'],
+          leadingUnderscore: 'require',
+        },
+      ],
+
       // Project-specific overrides
       '@typescript-eslint/interface-name-prefix': 'off',
       '@typescript-eslint/explicit-function-return-type': 'off',

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -47,12 +47,12 @@ export class AuthController {
   /**
    * Creates an instance of AuthController.
    *
-   * @param authService - The auth service.
-   * @param refreshTokenService - The refresh token service.
+   * @param _authService - The auth service.
+   * @param _refreshTokenService - The refresh token service.
    */
   constructor(
-    private readonly authService: AuthService,
-    private readonly refreshTokenService: UserRefreshTokenService,
+    private readonly _authService: AuthService,
+    private readonly _refreshTokenService: UserRefreshTokenService,
   ) {}
 
   @Post('register')
@@ -84,7 +84,7 @@ export class AuthController {
    * @returns A promise that resolves to the newly created UserEntity.
    */
   async register(@Body() createUserDto: CreateUserDto) {
-    return this.authService.register(createUserDto);
+    return this._authService.register(createUserDto);
   }
 
   @Post('login')
@@ -118,7 +118,7 @@ export class AuthController {
    * @returns A promise that resolves to an AuthLoginResultDto.
    */
   async login(@Body() userLoginDto: UserLoginDto) {
-    return this.authService.login(userLoginDto);
+    return this._authService.login(userLoginDto);
   }
 
   @Post('logout')
@@ -157,7 +157,7 @@ export class AuthController {
    * @returns A promise that resolves when logout is complete.
    */
   async logout(@Body() body: { tokenId: string }): Promise<void> {
-    await this.refreshTokenService.revokeUserRefreshToken(body.tokenId);
+    await this._refreshTokenService.revokeUserRefreshToken(body.tokenId);
   }
 
   @Post('verify-email')
@@ -186,7 +186,7 @@ export class AuthController {
    * @returns A promise that resolves to the verified UserEntity.
    */
   async verifyEmail(@Body() verifyEmailDto: VerifyEmailDto) {
-    return this.authService.verifyEmail(verifyEmailDto.token);
+    return this._authService.verifyEmail(verifyEmailDto.token);
   }
 
   @Post('resend-verification-email')
@@ -217,7 +217,7 @@ export class AuthController {
   async resendVerificationEmail(
     @Body() resendVerificationEmailDto: ResendVerificationEmailDto,
   ) {
-    return this.authService.resendVerificationEmail(
+    return this._authService.resendVerificationEmail(
       resendVerificationEmailDto.token,
     );
   }
@@ -248,7 +248,9 @@ export class AuthController {
   async requestPasswordReset(
     @Body() requestPasswordResetDto: RequestPasswordResetDto,
   ): Promise<void> {
-    return this.authService.requestPasswordReset(requestPasswordResetDto.email);
+    return this._authService.requestPasswordReset(
+      requestPasswordResetDto.email,
+    );
   }
 
   @Post('reset-password')
@@ -280,7 +282,7 @@ export class AuthController {
   async resetPassword(
     @Body() resetPasswordDto: ResetPasswordDto,
   ): Promise<void> {
-    return this.authService.resetPassword(
+    return this._authService.resetPassword(
       resetPasswordDto.token,
       resetPasswordDto.password,
     );
@@ -315,7 +317,7 @@ export class AuthController {
    * @returns A promise that resolves to an AuthRefreshResultDto.
    */
   async refresh(@Body() refreshTokenDto: UserRefreshTokenDto) {
-    return this.authService.refreshToken(refreshTokenDto.refresh_token);
+    return this._authService.refreshToken(refreshTokenDto.refresh_token);
   }
 
   @UseGuards(AuthGuard('jwt'))
@@ -342,6 +344,6 @@ export class AuthController {
    */
   async revoke(@UserId() userId: string, @Req() req: Request): Promise<void> {
     const tokenId = (req as any).user?.tokenId as string;
-    await this.authService.revokeToken(userId, tokenId);
+    await this._authService.revokeToken(userId, tokenId);
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -41,28 +41,28 @@ export class AuthService {
   /**
    * Creates an instance of AuthService.
    *
-   * @param userRepository - The user repository.
-   * @param userProfileRepository - The user profile repository.
-   * @param loginAttemptRepository - The login attempt repository.
-   * @param jwtService - The jwt service.
-   * @param userService - The user service.
-   * @param mailService - The mail service.
-   * @param refreshTokenService - The refresh token service.
+   * @param _userRepository - The user repository.
+   * @param _userProfileRepository - The user profile repository.
+   * @param _loginAttemptRepository - The login attempt repository.
+   * @param _jwtService - The jwt service.
+   * @param _userService - The user service.
+   * @param _mailService - The mail service.
+   * @param _refreshTokenService - The refresh token service.
    */
   constructor(
     @InjectRepository(UserEntity)
-    private readonly userRepository: Repository<UserEntity>,
+    private readonly _userRepository: Repository<UserEntity>,
 
     @InjectRepository(UserProfileEntity)
-    private readonly userProfileRepository: Repository<UserProfileEntity>,
+    private readonly _userProfileRepository: Repository<UserProfileEntity>,
 
     @InjectRepository(AuditLoginAttemptEntity)
-    private readonly loginAttemptRepository: Repository<AuditLoginAttemptEntity>,
+    private readonly _loginAttemptRepository: Repository<AuditLoginAttemptEntity>,
 
-    private readonly jwtService: JwtService,
-    private readonly userService: UserService,
-    private readonly mailService: MailService,
-    private readonly refreshTokenService: UserRefreshTokenService,
+    private readonly _jwtService: JwtService,
+    private readonly _userService: UserService,
+    private readonly _mailService: MailService,
+    private readonly _refreshTokenService: UserRefreshTokenService,
   ) {}
 
   /**
@@ -76,11 +76,11 @@ export class AuthService {
    * @throws InternalServerErrorException if an unexpected error occurs.
    */
   async register(userRegistration: CreateUserDto): Promise<UserEntity> {
-    if (await this.userService.doesEmailExist(userRegistration.email)) {
+    if (await this._userService.doesEmailExist(userRegistration.email)) {
       throw new ConflictException('Email already in use');
     }
 
-    if (await this.userService.doesUsernameExist(userRegistration.username)) {
+    if (await this._userService.doesUsernameExist(userRegistration.username)) {
       throw new ConflictException('Username already in use');
     }
 
@@ -96,14 +96,14 @@ export class AuthService {
       userRegistration.password,
     );
     const verificationToken = this.generateToken();
-    const newUser = this.userRepository.create({
+    const newUser = this._userRepository.create({
       email: userRegistration.email,
       password: hashedPassword,
       emailVerificationToken: verificationToken,
       emailVerificationTokenExpiry: this.generateTokenExpiryDate(),
     });
 
-    const newUserProfile = this.userProfileRepository.create({
+    const newUserProfile = this._userProfileRepository.create({
       userId: newUser.id,
       username: userRegistration.username,
       firstName: userRegistration.firstName,
@@ -113,13 +113,13 @@ export class AuthService {
     newUser.profile = newUserProfile;
 
     try {
-      const savedUser = await this.userRepository.save(newUser);
+      const savedUser = await this._userRepository.save(newUser);
 
       if (!savedUser) {
         throw new Error('User could not be saved');
       }
 
-      await this.mailService.sendVerificationEmail(
+      await this._mailService.sendVerificationEmail(
         savedUser.email,
         verificationToken,
       );
@@ -150,7 +150,7 @@ export class AuthService {
       throw new BadRequestException('Token missing');
     }
 
-    const user = await this.userRepository.findOne({
+    const user = await this._userRepository.findOne({
       where: { emailVerificationToken: token },
     });
 
@@ -164,7 +164,7 @@ export class AuthService {
     user.emailVerificationToken = null;
     user.emailVerificationTokenExpiry = null;
 
-    const updatedUser = await this.userRepository.save(user);
+    const updatedUser = await this._userRepository.save(user);
 
     // Send welcome email
     const emailSubject = `Welcome to the ${process.env.APP_TITLE}`;
@@ -187,7 +187,7 @@ export class AuthService {
       wordwrap: 130,
     });
 
-    await this.mailService.sendEmailToUser(
+    await this._mailService.sendEmailToUser(
       user.email,
       emailSubject,
       emailTextContent,
@@ -205,7 +205,7 @@ export class AuthService {
    * @throws BadRequestException if the email is already verified.
    */
   async resendVerificationEmail(token: string): Promise<void> {
-    const user = await this.userRepository.findOne({
+    const user = await this._userRepository.findOne({
       where: { emailVerificationToken: token },
     });
 
@@ -221,9 +221,12 @@ export class AuthService {
     user.emailVerificationToken = verificationToken;
     user.emailVerificationTokenExpiry = this.generateTokenExpiryDate();
 
-    await this.userRepository.save(user);
+    await this._userRepository.save(user);
 
-    await this.mailService.sendVerificationEmail(user.email, verificationToken);
+    await this._mailService.sendVerificationEmail(
+      user.email,
+      verificationToken,
+    );
   }
 
   /**
@@ -233,7 +236,7 @@ export class AuthService {
    * @returns The user object if the email and password are valid, otherwise null.
    */
   async validateUser(email: string, password: string): Promise<any> {
-    const user = await this.userService.findByEmail(email);
+    const user = await this._userService.findByEmail(email);
     if (user && (await user.comparePassword(password))) {
       if (!CurrentContextHelper.userUuid) {
         // Store the user ID for audit logging
@@ -252,7 +255,7 @@ export class AuthService {
   async validateUserFromPayload(
     payload: JwtPayloadInterface,
   ): Promise<UserEntity | null> {
-    const user = await this.userRepository.findOne({
+    const user = await this._userRepository.findOne({
       where: {
         id: payload.sub,
         email: payload.email,
@@ -342,16 +345,16 @@ export class AuthService {
 
     // Update last login time
     user.lastLoginAt = new Date();
-    await this.userRepository.save(user);
+    await this._userRepository.save(user);
 
     // Send user logged in notification
-    await this.mailService.sendUserLoggedInNotification(
+    await this._mailService.sendUserLoggedInNotification(
       user.email,
       user.profile?.firstName || 'Captain!',
     );
 
     return {
-      access_token: this.jwtService.sign(payload),
+      access_token: this._jwtService.sign(payload),
       refresh_token: newUserRefreshToken,
       expires_in: +process.env.AUTH_TOKEN_EXPIRES_IN!,
       user_id: user.id,
@@ -387,7 +390,7 @@ export class AuthService {
       throw new BadRequestException('Invalid request');
     }
 
-    const user = await this.userService.findByEmail(email);
+    const user = await this._userService.findByEmail(email);
     if (!user) {
       throw new BadRequestException('Invalid request'); //NOTE: Changed from NotFoundException to not show if email exists
     }
@@ -404,9 +407,9 @@ export class AuthService {
     user.passwordResetToken = passwordResetToken;
     user.passwordResetTokenExpiry = this.generateTokenExpiryDate();
 
-    await this.userRepository.save(user);
+    await this._userRepository.save(user);
 
-    await this.mailService.sendPasswordResetEmail(
+    await this._mailService.sendPasswordResetEmail(
       user.email,
       passwordResetToken,
       user.profile?.firstName || 'Captain!',
@@ -431,7 +434,7 @@ export class AuthService {
       throw new BadRequestException('Password missing from request');
     }
 
-    const user = await this.userRepository.findOne({
+    const user = await this._userRepository.findOne({
       where: { passwordResetToken: token },
       relations: { profile: true },
     });
@@ -448,14 +451,14 @@ export class AuthService {
     user.passwordResetTokenExpiry = null;
     user.lastPasswordReset = new Date();
 
-    await this.userRepository.save(user);
+    await this._userRepository.save(user);
 
-    await this.mailService.sendPasswordChangedEmail(
+    await this._mailService.sendPasswordChangedEmail(
       user.email,
       user.profile?.firstName || 'Captain!',
     );
 
-    await this.refreshTokenService.revokeAllTokensForUser(user.id);
+    await this._refreshTokenService.revokeAllTokensForUser(user.id);
   }
 
   /**
@@ -472,10 +475,10 @@ export class AuthService {
     refresh_token: string;
   }> {
     try {
-      const payload = this.jwtService.verify(refreshToken);
+      const payload = this._jwtService.verify(refreshToken);
 
       // Load the user with their refresh tokens using the user ID
-      const user = await this.userRepository.findOne({
+      const user = await this._userRepository.findOne({
         where: { id: payload.sub },
         relations: { refreshTokens: true },
       });
@@ -498,10 +501,10 @@ export class AuthService {
       const newUserRefreshToken = await this.issueRefreshToken(user);
 
       // Revoke the old refresh token
-      await this.refreshTokenService.revokeToken(user.id, refreshToken);
+      await this._refreshTokenService.revokeToken(user.id, refreshToken);
 
       return {
-        access_token: this.jwtService.sign(newPayload),
+        access_token: this._jwtService.sign(newPayload),
         refresh_token: newUserRefreshToken,
         expires_in: +process.env.AUTH_TOKEN_EXPIRES_IN!,
       };
@@ -522,13 +525,13 @@ export class AuthService {
    * @throws HttpException if the user is not found.
    */
   async revokeToken(id: string, tokenId: string): Promise<void> {
-    const user = await this.userRepository.findOne({ where: { id: id } });
+    const user = await this._userRepository.findOne({ where: { id: id } });
     if (!user) {
       throw new HttpException('User not found', HttpStatus.NOT_FOUND);
     }
 
     // Revoke the matching refresh token for this user
-    await this.refreshTokenService.revokeToken(id, tokenId);
+    await this._refreshTokenService.revokeToken(id, tokenId);
   }
 
   /**
@@ -582,7 +585,7 @@ export class AuthService {
     const expiryHours = this.getRefreshTokenExpiryHours();
     const jwtId = this.generateToken();
 
-    const token = this.jwtService.sign(
+    const token = this._jwtService.sign(
       { email: user.email, sub: user.id },
       {
         expiresIn: `${expiryHours}h`,
@@ -590,7 +593,7 @@ export class AuthService {
       },
     );
 
-    await this.refreshTokenService.create({
+    await this._refreshTokenService.create({
       user: user as UserEntity,
       tokenId: token,
       jwtId,
@@ -645,7 +648,7 @@ export class AuthService {
     loginAttemptRecord.success = success;
 
     await validateOrReject(loginAttemptRecord);
-    await this.loginAttemptRepository.save(loginAttemptRecord);
+    await this._loginAttemptRepository.save(loginAttemptRecord);
   }
 
   /**

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -16,21 +16,21 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   /**
    * Creates an instance of JwtStrategy.
    *
-   * @param authService - The auth service.
-   * @param configService - The config service.
-   * @param secretsService - The secrets service.
+   * @param _authService - The auth service.
+   * @param _configService - The config service.
+   * @param _secretsService - The secrets service.
    */
   constructor(
-    private readonly authService: AuthService,
-    private readonly configService: ConfigService,
-    private readonly secretsService: SecretsService,
+    private readonly _authService: AuthService,
+    private readonly _configService: ConfigService,
+    private readonly _secretsService: SecretsService,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
       secretOrKeyProvider: (_request, _rawJwtToken, done) => {
-        const secretName = this.configService.get<string>('AWS_SECRET_NAME')!;
-        this.secretsService
+        const secretName = this._configService.get<string>('AWS_SECRET_NAME')!;
+        this._secretsService
           .getSecret(secretName)
           .then(secretObject => {
             done(null, secretObject.jwtSecret);
@@ -51,7 +51,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
    * @returns The user object if the payload is valid.
    */
   async validate(payload: JwtPayloadInterface) {
-    const user = await this.authService.validateUserFromPayload(payload);
+    const user = await this._authService.validateUserFromPayload(payload);
     if (!user) {
       throw new UnauthorizedException();
     }

--- a/src/auth/local.strategy.ts
+++ b/src/auth/local.strategy.ts
@@ -9,9 +9,9 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
   /**
    * Creates an instance of LocalStrategy.
    *
-   * @param authService - The auth service.
+   * @param _authService - The auth service.
    */
-  constructor(private readonly authService: AuthService) {
+  constructor(private readonly _authService: AuthService) {
     super({ usernameField: 'email' }); // Use 'email' instead of the default 'username'
   }
 
@@ -23,7 +23,7 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
    * @returns A promise that resolves when the operation completes.
    */
   async validate(email: string, password: string): Promise<any> {
-    const user = await this.authService.validateUser(email, password);
+    const user = await this._authService.validateUser(email, password);
     if (!user) {
       throw new UnauthorizedException();
     }

--- a/src/auth/roles.guard.ts
+++ b/src/auth/roles.guard.ts
@@ -20,9 +20,9 @@ export class RolesGuard implements CanActivate {
   /**
    * Creates an instance of RolesGuard.
    *
-   * @param reflector - Used to read role metadata from handlers/controllers.
+   * @param _reflector - Used to read role metadata from handlers/controllers.
    */
-  constructor(private readonly reflector: Reflector) {}
+  constructor(private readonly _reflector: Reflector) {}
 
   /**
    * Determines whether the current request satisfies the required roles.
@@ -32,7 +32,7 @@ export class RolesGuard implements CanActivate {
    * @throws ForbiddenException when the user lacks a required role.
    */
   canActivate(context: ExecutionContext): boolean {
-    const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(
+    const requiredRoles = this._reflector.getAllAndOverride<UserRole[]>(
       ROLES_KEY,
       [context.getHandler(), context.getClass()],
     );

--- a/src/auth/user-id.middleware.ts
+++ b/src/auth/user-id.middleware.ts
@@ -20,12 +20,12 @@ export class UserIdMiddleware implements NestMiddleware {
   /**
    * Creates an instance of UserIdMiddleware.
    *
-   * @param configService - The config service.
-   * @param secretsService - The secrets service.
+   * @param _configService - The config service.
+   * @param _secretsService - The secrets service.
    */
   constructor(
-    private readonly configService: ConfigService,
-    private readonly secretsService: SecretsService,
+    private readonly _configService: ConfigService,
+    private readonly _secretsService: SecretsService,
   ) {}
 
   /**
@@ -78,8 +78,8 @@ export class UserIdMiddleware implements NestMiddleware {
     req: Request,
   ): Promise<void> {
     try {
-      const secretObject = await this.secretsService.getSecret(
-        this.configService.get<string>('AWS_SECRET_NAME')!,
+      const secretObject = await this._secretsService.getSecret(
+        this._configService.get<string>('AWS_SECRET_NAME')!,
       );
       if (secretObject?.jwtSecret) {
         const decoded = jwt.verify(token, secretObject.jwtSecret) as JwtPayload;

--- a/src/common/interceptors/logging.interceptor.spec.ts
+++ b/src/common/interceptors/logging.interceptor.spec.ts
@@ -52,7 +52,7 @@ describe('LoggingInterceptor', () => {
 
   it('should log the successful request and set Sentry tags', done => {
     const loggerSpy = jest
-      .spyOn((interceptor as any).logger, 'log')
+      .spyOn((interceptor as any)._logger, 'log')
       .mockImplementation(() => {});
 
     interceptor
@@ -77,7 +77,7 @@ describe('LoggingInterceptor', () => {
 
   it('should log failed requests and capture exception in Sentry', done => {
     const loggerSpy = jest
-      .spyOn((interceptor as any).logger, 'error')
+      .spyOn((interceptor as any)._logger, 'error')
       .mockImplementation(() => {});
     const error = new Error('Test error');
     mockCallHandler.handle = jest

--- a/src/common/interceptors/logging.interceptor.ts
+++ b/src/common/interceptors/logging.interceptor.ts
@@ -12,7 +12,7 @@ import { tap } from 'rxjs/operators';
 
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
-  private readonly logger = new Logger('HTTP');
+  private readonly _logger = new Logger('HTTP');
 
   /**
    * Intercepts the request pipeline.
@@ -38,11 +38,11 @@ export class LoggingInterceptor implements NestInterceptor {
       tap({
         next: () => {
           const timeout = Date.now() - now;
-          this.logger.log(`${method} ${url} ${timeout}ms`);
+          this._logger.log(`${method} ${url} ${timeout}ms`);
         },
         error: err => {
           const timeout = Date.now() - now;
-          this.logger.error(
+          this._logger.error(
             `${method} ${url} ${timeout}ms - Error: ${err.message}`,
           );
           // Manually capture the exception to ensure Sentry tracks it

--- a/src/contact/contact.controller.ts
+++ b/src/contact/contact.controller.ts
@@ -15,9 +15,9 @@ export class ContactController {
   /**
    * Creates an instance of ContactController.
    *
-   * @param contactService - The contact service.
+   * @param _contactService - The contact service.
    */
-  constructor(private readonly contactService: ContactService) {}
+  constructor(private readonly _contactService: ContactService) {}
 
   /**
    * Submit a contact request and send it to the support inbox.
@@ -34,6 +34,6 @@ export class ContactController {
     description: 'The contact request has been sent.',
   })
   async submitContact(@Body() payload: ContactRequestDto): Promise<void> {
-    await this.contactService.submitContactRequest(payload);
+    await this._contactService.submitContactRequest(payload);
   }
 }

--- a/src/contact/contact.service.ts
+++ b/src/contact/contact.service.ts
@@ -13,13 +13,13 @@ export class ContactService {
   /**
    * Creates an instance of ContactService.
    *
-   * @param mailService - The mail service.
-   * @param contactRequestRepository - The contact request repository.
+   * @param _mailService - The mail service.
+   * @param _contactRequestRepository - The contact request repository.
    */
   constructor(
-    private readonly mailService: MailService,
+    private readonly _mailService: MailService,
     @InjectRepository(ContactRequestEntity)
-    private readonly contactRequestRepository: Repository<ContactRequestEntity>,
+    private readonly _contactRequestRepository: Repository<ContactRequestEntity>,
   ) {}
 
   /**
@@ -31,26 +31,26 @@ export class ContactService {
    */
   async submitContactRequest(payload: ContactRequestDto): Promise<void> {
     const maskedEmail = this.maskEmail(payload.email);
-    const contactRequest = this.contactRequestRepository.create({
+    const contactRequest = this._contactRequestRepository.create({
       name: payload.name,
       emailMasked: maskedEmail,
       topic: payload.topic,
       message: payload.message,
     });
-    await this.contactRequestRepository.save(contactRequest);
+    await this._contactRequestRepository.save(contactRequest);
 
     const supportSubject = `Contact request: ${payload.topic}`;
     const supportTextContent = this.buildSupportTextContent(payload);
     const supportHtmlContent = this.buildSupportHtmlContent(payload);
 
-    const supportMessage = this.mailService.generateEmailMessageObject(
+    const supportMessage = this._mailService.generateEmailMessageObject(
       SUPPORT_EMAIL,
       supportSubject,
       supportTextContent,
       supportHtmlContent,
     );
 
-    await this.mailService.sendEmailWithFallback({
+    await this._mailService.sendEmailWithFallback({
       ...supportMessage,
       replyTo: {
         email: payload.email,
@@ -61,14 +61,14 @@ export class ContactService {
     const userSubject = `We received your message`;
     const userTextContent = this.buildUserTextContent(payload);
     const userHtmlContent = this.buildUserHtmlContent(payload);
-    const userMessage = this.mailService.generateEmailMessageObject(
+    const userMessage = this._mailService.generateEmailMessageObject(
       payload.email,
       userSubject,
       userTextContent,
       userHtmlContent,
     );
 
-    await this.mailService.sendEmailWithFallback(userMessage);
+    await this._mailService.sendEmailWithFallback(userMessage);
   }
 
   /**

--- a/src/cron/cron.service.spec.ts
+++ b/src/cron/cron.service.spec.ts
@@ -172,7 +172,7 @@ describe('CronService', () => {
         .spyOn(userAccountCleanupService, 'cleanup')
         .mockResolvedValue(undefined);
 
-      const logger = (service as unknown as { logger: Logger }).logger;
+      const logger = (service as unknown as { _logger: Logger })._logger;
       const logSpy = jest
         .spyOn(logger, 'log')
         .mockImplementation((message: unknown) => {

--- a/src/cron/cron.service.ts
+++ b/src/cron/cron.service.ts
@@ -9,23 +9,23 @@ import { UserAccountCleanupService } from './jobs/user-account-cleanup/user-acco
 
 @Injectable()
 export class CronService {
-  private readonly logger = new Logger(CronService.name);
+  private readonly _logger = new Logger(CronService.name);
 
   /**
    * Creates an instance of CronService.
    *
-   * @param auditCleanupService - The audit cleanup service.
-   * @param auditLoginAttemptCleanupService - The audit login attempt cleanup service.
-   * @param contactRequestCleanupService - The contact request cleanup service.
-   * @param sesAuditCleanupService - The ses audit cleanup service.
-   * @param userAccountCleanupService - The user account cleanup service.
+   * @param _auditCleanupService - The audit cleanup service.
+   * @param _auditLoginAttemptCleanupService - The audit login attempt cleanup service.
+   * @param _contactRequestCleanupService - The contact request cleanup service.
+   * @param _sesAuditCleanupService - The ses audit cleanup service.
+   * @param _userAccountCleanupService - The user account cleanup service.
    */
   constructor(
-    private readonly auditCleanupService: AuditCleanupService,
-    private readonly auditLoginAttemptCleanupService: AuditLoginAttemptCleanupService,
-    private readonly contactRequestCleanupService: ContactRequestCleanupService,
-    private readonly sesAuditCleanupService: SesAuditCleanupService,
-    private readonly userAccountCleanupService: UserAccountCleanupService,
+    private readonly _auditCleanupService: AuditCleanupService,
+    private readonly _auditLoginAttemptCleanupService: AuditLoginAttemptCleanupService,
+    private readonly _contactRequestCleanupService: ContactRequestCleanupService,
+    private readonly _sesAuditCleanupService: SesAuditCleanupService,
+    private readonly _userAccountCleanupService: UserAccountCleanupService,
   ) {}
 
   /**
@@ -42,7 +42,7 @@ export class CronService {
   @Cron('26 3 * * *', { timeZone: CRON_TIMEZONE })
   @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT, { timeZone: CRON_TIMEZONE })
   async dailyMidnightJobs() {
-    this.logger.log('Running daily midnight jobs...');
+    this._logger.log('Running daily midnight jobs...');
     try {
       await this.handleAuditCleanup();
       await this.handleAuditLoginAttemptCleanup();
@@ -50,7 +50,7 @@ export class CronService {
       await this.handleSesAuditCleanup();
       await this.handleUserAccountCleanup();
     } catch (error) {
-      this.logger.error('Error running daily midnight jobs:', error);
+      this._logger.error('Error running daily midnight jobs:', error);
     }
   }
 
@@ -60,12 +60,12 @@ export class CronService {
    * to proceed.
    */
   private async handleAuditCleanup() {
-    this.logger.log('Starting audit cleanup job...');
+    this._logger.log('Starting audit cleanup job...');
     try {
-      await this.auditCleanupService.cleanup();
-      this.logger.log('Audit cleanup job completed successfully.');
+      await this._auditCleanupService.cleanup();
+      this._logger.log('Audit cleanup job completed successfully.');
     } catch (error) {
-      this.logger.error('Error running audit cleanup job:', error);
+      this._logger.error('Error running audit cleanup job:', error);
     }
   }
 
@@ -75,14 +75,14 @@ export class CronService {
    * to proceed.
    */
   private async handleAuditLoginAttemptCleanup() {
-    this.logger.log('Starting audit login attempt cleanup job...');
+    this._logger.log('Starting audit login attempt cleanup job...');
     try {
-      await this.auditLoginAttemptCleanupService.cleanup();
-      this.logger.log(
+      await this._auditLoginAttemptCleanupService.cleanup();
+      this._logger.log(
         'Audit login attempt cleanup job completed successfully.',
       );
     } catch (error) {
-      this.logger.error(
+      this._logger.error(
         'Error running audit login attempt cleanup job:',
         error,
       );
@@ -95,12 +95,12 @@ export class CronService {
    * swallowed to allow subsequent jobs to proceed.
    */
   private async handleContactRequestCleanup() {
-    this.logger.log('Starting contact request cleanup job...');
+    this._logger.log('Starting contact request cleanup job...');
     try {
-      await this.contactRequestCleanupService.cleanup();
-      this.logger.log('Contact request cleanup job completed successfully.');
+      await this._contactRequestCleanupService.cleanup();
+      this._logger.log('Contact request cleanup job completed successfully.');
     } catch (error) {
-      this.logger.error('Error running contact request cleanup job:', error);
+      this._logger.error('Error running contact request cleanup job:', error);
     }
   }
 
@@ -110,12 +110,12 @@ export class CronService {
    * Errors are logged and swallowed to allow subsequent jobs to proceed.
    */
   private async handleSesAuditCleanup() {
-    this.logger.log('Starting SES audit cleanup job...');
+    this._logger.log('Starting SES audit cleanup job...');
     try {
-      await this.sesAuditCleanupService.cleanup();
-      this.logger.log('SES audit cleanup job completed successfully.');
+      await this._sesAuditCleanupService.cleanup();
+      this._logger.log('SES audit cleanup job completed successfully.');
     } catch (error) {
-      this.logger.error('Error running SES audit cleanup job:', error);
+      this._logger.error('Error running SES audit cleanup job:', error);
     }
   }
 
@@ -124,12 +124,12 @@ export class CronService {
    * accounts once their retention period has elapsed.
    */
   private async handleUserAccountCleanup() {
-    this.logger.log('Starting user account cleanup job...');
+    this._logger.log('Starting user account cleanup job...');
     try {
-      await this.userAccountCleanupService.cleanup();
-      this.logger.log('User account cleanup job completed successfully.');
+      await this._userAccountCleanupService.cleanup();
+      this._logger.log('User account cleanup job completed successfully.');
     } catch (error) {
-      this.logger.error('Error running user account cleanup job:', error);
+      this._logger.error('Error running user account cleanup job:', error);
     }
   }
 }

--- a/src/cron/jobs/audit-cleanup/audit-cleanup.service.ts
+++ b/src/cron/jobs/audit-cleanup/audit-cleanup.service.ts
@@ -9,16 +9,16 @@ import { LessThan, Repository } from 'typeorm';
 
 @Injectable()
 export class AuditCleanupService {
-  private readonly logger = new Logger(AuditCleanupService.name);
+  private readonly _logger = new Logger(AuditCleanupService.name);
 
   /**
    * Creates an instance of AuditCleanupService.
    *
-   * @param auditRepository - The audit repository.
+   * @param _auditRepository - The audit repository.
    */
   constructor(
     @InjectRepository(AuditEntity)
-    private readonly auditRepository: Repository<AuditEntity>,
+    private readonly _auditRepository: Repository<AuditEntity>,
   ) {}
 
   /**
@@ -31,11 +31,11 @@ export class AuditCleanupService {
       thresholdDate.getDate() - AUDIT_DATA_NUKE_THRESHOLD_DAYS,
     );
 
-    const deleteResult = await this.auditRepository.delete({
+    const deleteResult = await this._auditRepository.delete({
       createdAt: LessThan(thresholdDate),
     });
 
-    this.logger.log(
+    this._logger.log(
       `Deleted ${deleteResult.affected} audit records older than ${AUDIT_DATA_NUKE_THRESHOLD_DAYS} days.`,
     );
 
@@ -45,12 +45,12 @@ export class AuditCleanupService {
       ipNukeThresholdDate.getDate() - AUDIT_IP_NUKE_THRESHOLD_DAYS,
     );
 
-    const updateResult = await this.auditRepository.update(
+    const updateResult = await this._auditRepository.update(
       { createdAt: LessThan(ipNukeThresholdDate) },
       { ipAddress: null },
     );
 
-    this.logger.log(
+    this._logger.log(
       `Set IP address to null for ${updateResult.affected} audit records older than ${AUDIT_IP_NUKE_THRESHOLD_DAYS} days.`,
     );
   }

--- a/src/cron/jobs/audit-login-attempt-cleanup/audit-login-attempt-cleanup.service.ts
+++ b/src/cron/jobs/audit-login-attempt-cleanup/audit-login-attempt-cleanup.service.ts
@@ -9,16 +9,16 @@ import { LessThan, Repository } from 'typeorm';
 
 @Injectable()
 export class AuditLoginAttemptCleanupService {
-  private readonly logger = new Logger(AuditLoginAttemptCleanupService.name);
+  private readonly _logger = new Logger(AuditLoginAttemptCleanupService.name);
 
   /**
    * Creates an instance of AuditLoginAttemptCleanupService.
    *
-   * @param auditLoginAttemptRepository - The audit login attempt repository.
+   * @param _auditLoginAttemptRepository - The audit login attempt repository.
    */
   constructor(
     @InjectRepository(AuditLoginAttemptEntity)
-    private readonly auditLoginAttemptRepository: Repository<AuditLoginAttemptEntity>,
+    private readonly _auditLoginAttemptRepository: Repository<AuditLoginAttemptEntity>,
   ) {}
 
   /**
@@ -31,11 +31,11 @@ export class AuditLoginAttemptCleanupService {
       thresholdDate.getDate() - AUDIT_DATA_NUKE_THRESHOLD_DAYS,
     );
 
-    const deleteResult = await this.auditLoginAttemptRepository.delete({
+    const deleteResult = await this._auditLoginAttemptRepository.delete({
       createdAt: LessThan(thresholdDate),
     });
 
-    this.logger.log(
+    this._logger.log(
       `Deleted ${deleteResult.affected} audit login attempt records older than ${AUDIT_DATA_NUKE_THRESHOLD_DAYS} days.`,
     );
 
@@ -45,12 +45,12 @@ export class AuditLoginAttemptCleanupService {
       ipNukeThresholdDate.getDate() - AUDIT_IP_NUKE_THRESHOLD_DAYS,
     );
 
-    const updateResult = await this.auditLoginAttemptRepository.update(
+    const updateResult = await this._auditLoginAttemptRepository.update(
       { createdAt: LessThan(ipNukeThresholdDate) },
       { ipAddress: null },
     );
 
-    this.logger.log(
+    this._logger.log(
       `Set IP address to null for ${updateResult.affected} audit login attempt records older than ${AUDIT_IP_NUKE_THRESHOLD_DAYS} days.`,
     );
   }

--- a/src/cron/jobs/contact-request-cleanup/contact-request-cleanup.service.ts
+++ b/src/cron/jobs/contact-request-cleanup/contact-request-cleanup.service.ts
@@ -9,16 +9,16 @@ import { IsNull, LessThan, Not, Repository } from 'typeorm';
 
 @Injectable()
 export class ContactRequestCleanupService {
-  private readonly logger = new Logger(ContactRequestCleanupService.name);
+  private readonly _logger = new Logger(ContactRequestCleanupService.name);
 
   /**
    * Creates an instance of ContactRequestCleanupService.
    *
-   * @param contactRequestRepository - The contact request repository.
+   * @param _contactRequestRepository - The contact request repository.
    */
   constructor(
     @InjectRepository(ContactRequestEntity)
-    private readonly contactRequestRepository: Repository<ContactRequestEntity>,
+    private readonly _contactRequestRepository: Repository<ContactRequestEntity>,
   ) {}
 
   /**
@@ -30,11 +30,11 @@ export class ContactRequestCleanupService {
       recordThresholdDate.getDate() - CONTACT_REQUEST_RECORD_RETENTION_DAYS,
     );
 
-    const deleteResult = await this.contactRequestRepository.delete({
+    const deleteResult = await this._contactRequestRepository.delete({
       createdAt: LessThan(recordThresholdDate),
     });
 
-    this.logger.log(
+    this._logger.log(
       `Deleted ${deleteResult.affected} contact requests older than ${CONTACT_REQUEST_RECORD_RETENTION_DAYS} days.`,
     );
 
@@ -43,7 +43,7 @@ export class ContactRequestCleanupService {
       thresholdDate.getDate() - CONTACT_REQUEST_EMAIL_MASK_RETENTION_DAYS,
     );
 
-    const updateResult = await this.contactRequestRepository.update(
+    const updateResult = await this._contactRequestRepository.update(
       {
         createdAt: LessThan(thresholdDate),
         emailMasked: Not(IsNull()),
@@ -51,7 +51,7 @@ export class ContactRequestCleanupService {
       { emailMasked: null },
     );
 
-    this.logger.log(
+    this._logger.log(
       `Cleared ${updateResult.affected} masked contact emails older than ${CONTACT_REQUEST_EMAIL_MASK_RETENTION_DAYS} days.`,
     );
   }

--- a/src/cron/jobs/ses-audit-cleanup/ses-audit-cleanup.service.ts
+++ b/src/cron/jobs/ses-audit-cleanup/ses-audit-cleanup.service.ts
@@ -29,16 +29,16 @@ import { LessThan, Repository } from 'typeorm';
  */
 @Injectable()
 export class SesAuditCleanupService {
-  private readonly logger = new Logger(SesAuditCleanupService.name);
+  private readonly _logger = new Logger(SesAuditCleanupService.name);
 
   /**
    * Creates an instance of SesAuditCleanupService.
    *
-   * @param sesEventRepository - The ses event repository.
+   * @param _sesEventRepository - The ses event repository.
    */
   constructor(
     @InjectRepository(SesEventEntity)
-    private readonly sesEventRepository: Repository<SesEventEntity>,
+    private readonly _sesEventRepository: Repository<SesEventEntity>,
   ) {}
 
   /**
@@ -64,12 +64,12 @@ export class SesAuditCleanupService {
     const threshold = new Date();
     threshold.setDate(threshold.getDate() - SES_AUDIT_RETENTION_DAYS);
 
-    const result = await this.sesEventRepository.delete({
+    const result = await this._sesEventRepository.delete({
       suppress: false,
       createdAt: LessThan(threshold),
     });
 
-    this.logger.log(
+    this._logger.log(
       `Deleted ${result.affected ?? 0} non-suppressing SES audit records older than ${SES_AUDIT_RETENTION_DAYS} days.`,
     );
   }
@@ -87,12 +87,12 @@ export class SesAuditCleanupService {
     const threshold = new Date();
     threshold.setDate(threshold.getDate() - SES_SUPPRESSION_RETENTION_DAYS);
 
-    const result = await this.sesEventRepository.delete({
+    const result = await this._sesEventRepository.delete({
       suppress: true,
       createdAt: LessThan(threshold),
     });
 
-    this.logger.log(
+    this._logger.log(
       `Deleted ${result.affected ?? 0} suppression SES audit records older than ${SES_SUPPRESSION_RETENTION_DAYS} days.`,
     );
   }

--- a/src/cron/jobs/user-account-cleanup/user-account-cleanup.service.ts
+++ b/src/cron/jobs/user-account-cleanup/user-account-cleanup.service.ts
@@ -9,28 +9,28 @@ import { LessThan, Repository } from 'typeorm';
 
 @Injectable()
 export class UserAccountCleanupService {
-  private readonly logger = new Logger(UserAccountCleanupService.name);
+  private readonly _logger = new Logger(UserAccountCleanupService.name);
 
   /**
    * Creates an instance of UserAccountCleanupService.
    *
-   * @param userRepository - User repository.
-   * @param userProfileRepository - User profile repository.
-   * @param userRefreshTokenRepository - User refresh token repository.
-   * @param accountRepository - Account repository.
+   * @param _userRepository - User repository.
+   * @param _userProfileRepository - User profile repository.
+   * @param _userRefreshTokenRepository - User refresh token repository.
+   * @param _accountRepository - Account repository.
    */
   constructor(
     @InjectRepository(UserEntity)
-    private readonly userRepository: Repository<UserEntity>,
+    private readonly _userRepository: Repository<UserEntity>,
 
     @InjectRepository(UserProfileEntity)
-    private readonly userProfileRepository: Repository<UserProfileEntity>,
+    private readonly _userProfileRepository: Repository<UserProfileEntity>,
 
     @InjectRepository(UserRefreshTokenEntity)
-    private readonly userRefreshTokenRepository: Repository<UserRefreshTokenEntity>,
+    private readonly _userRefreshTokenRepository: Repository<UserRefreshTokenEntity>,
 
     @InjectRepository(AccountEntity)
-    private readonly accountRepository: Repository<AccountEntity>,
+    private readonly _accountRepository: Repository<AccountEntity>,
   ) {}
 
   /**
@@ -43,14 +43,14 @@ export class UserAccountCleanupService {
       thresholdDate.getDate() - CLOSED_ACCOUNT_RETENTION_DAYS,
     );
 
-    const usersToDelete = await this.userRepository.find({
+    const usersToDelete = await this._userRepository.find({
       where: { deletedAt: LessThan(thresholdDate) },
       withDeleted: true,
       select: { id: true },
     });
 
     if (!usersToDelete.length) {
-      this.logger.log(
+      this._logger.log(
         `No closed accounts eligible for hard deletion (threshold: ${CLOSED_ACCOUNT_RETENTION_DAYS} days).`,
       );
       return;
@@ -59,13 +59,13 @@ export class UserAccountCleanupService {
     const userIds = usersToDelete.map(user => user.id);
 
     // Purge dependent records with non-cascading FKs first.
-    await this.userRefreshTokenRepository
+    await this._userRefreshTokenRepository
       .createQueryBuilder()
       .delete()
       .where('"userId" IN (:...userIds)', { userIds })
       .execute();
 
-    await this.userProfileRepository
+    await this._userProfileRepository
       .createQueryBuilder()
       .delete()
       .where('"userId" IN (:...userIds)', { userIds })
@@ -73,19 +73,19 @@ export class UserAccountCleanupService {
 
     // Account rows are cascade-linked to user and remove characters/endeavour
     // rows automatically at the DB level on hard delete.
-    await this.accountRepository
+    await this._accountRepository
       .createQueryBuilder()
       .delete()
       .where('"userId" IN (:...userIds)', { userIds })
       .execute();
 
-    await this.userRepository
+    await this._userRepository
       .createQueryBuilder()
       .delete()
       .where('id IN (:...userIds)', { userIds })
       .execute();
 
-    this.logger.log(
+    this._logger.log(
       `Hard deleted ${userIds.length} closed user account(s) older than ${CLOSED_ACCOUNT_RETENTION_DAYS} days.`,
     );
   }

--- a/src/database/account-seeder/account-seeder.service.ts
+++ b/src/database/account-seeder/account-seeder.service.ts
@@ -23,14 +23,14 @@ export class AccountSeederService {
   /**
    * Creates an instance of AccountSeederService.
    *
-   * @param platformService - Service for managing platform entities.
-   * @param launcherService - Service for managing launcher entities.
-   * @param platformLauncherService - Service for managing platform-launcher relationships.
+   * @param _platformService - Service for managing platform entities.
+   * @param _launcherService - Service for managing launcher entities.
+   * @param _platformLauncherService - Service for managing platform-launcher relationships.
    */
   constructor(
-    private readonly platformService: PlatformService,
-    private readonly launcherService: LauncherService,
-    private readonly platformLauncherService: PlatformLauncherService,
+    private readonly _platformService: PlatformService,
+    private readonly _launcherService: LauncherService,
+    private readonly _platformLauncherService: PlatformLauncherService,
   ) {}
 
   /**
@@ -69,7 +69,7 @@ export class AccountSeederService {
     for (const platform of platforms) {
       const existingPlatform = await this.findPlatformByName(platform);
       if (!existingPlatform) {
-        await this.platformService.create({ name: platform });
+        await this._platformService.create({ name: platform });
       }
     }
   }
@@ -89,7 +89,7 @@ export class AccountSeederService {
     for (const launcher of launchers) {
       const existingLauncher = await this.findLauncherByName(launcher);
       if (!existingLauncher) {
-        await this.launcherService.create({ name: launcher });
+        await this._launcherService.create({ name: launcher });
       }
     }
   }
@@ -128,7 +128,7 @@ export class AccountSeederService {
           launcher.id,
         );
         if (!existingCombo) {
-          await this.platformLauncherService.addPlatformLauncherRelation(
+          await this._platformLauncherService.addPlatformLauncherRelation(
             platform.id,
             launcher.id,
           );
@@ -152,7 +152,7 @@ export class AccountSeederService {
     name: string,
   ): Promise<PlatformEntity | null> {
     try {
-      return await this.platformService.findOneByName(name);
+      return await this._platformService.findOneByName(name);
     } catch (error) {
       if (error instanceof NotFoundException) {
         return null;
@@ -177,7 +177,7 @@ export class AccountSeederService {
     name: string,
   ): Promise<LauncherEntity | null> {
     try {
-      return await this.launcherService.findOneByName(name);
+      return await this._launcherService.findOneByName(name);
     } catch (error) {
       if (error instanceof NotFoundException) {
         return null;
@@ -204,7 +204,10 @@ export class AccountSeederService {
     launcherId: string,
   ) {
     try {
-      return await this.platformLauncherService.findOne(platformId, launcherId);
+      return await this._platformLauncherService.findOne(
+        platformId,
+        launcherId,
+      );
     } catch (error) {
       if (error instanceof NotFoundException) {
         return null;

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -65,14 +65,14 @@ export class DatabaseModule implements OnModuleInit {
   /**
    * Creates an instance of DatabaseModule.
    *
-   * @param databaseService - Service for database readiness and configuration.
-   * @param userSeederService - Service for seeding user reference data.
-   * @param accountSeederService - Service for seeding account reference data (platforms, launchers).
+   * @param _databaseService - Service for database readiness and configuration.
+   * @param _userSeederService - Service for seeding user reference data.
+   * @param _accountSeederService - Service for seeding account reference data (platforms, launchers).
    */
   constructor(
-    private readonly databaseService: DatabaseService,
-    private readonly userSeederService: UserSeederService,
-    private readonly accountSeederService: AccountSeederService,
+    private readonly _databaseService: DatabaseService,
+    private readonly _userSeederService: UserSeederService,
+    private readonly _accountSeederService: AccountSeederService,
   ) {}
 
   /**
@@ -100,7 +100,7 @@ export class DatabaseModule implements OnModuleInit {
    */
   async onModuleInit() {
     try {
-      await this.databaseService.assertDatabaseReadyForSeeding();
+      await this._databaseService.assertDatabaseReadyForSeeding();
       Logger.log('Database readiness check passed.', 'DatabaseModule');
     } catch (error) {
       Logger.error(
@@ -112,21 +112,21 @@ export class DatabaseModule implements OnModuleInit {
     }
 
     try {
-      await this.databaseService.setDatabaseTimezone();
+      await this._databaseService.setDatabaseTimezone();
       Logger.log('Database timezone set successfully.', 'DatabaseModule');
     } catch (error) {
       Logger.error('Failed to set database timezone:', error, 'DatabaseModule');
     }
 
     try {
-      await this.userSeederService.seed();
+      await this._userSeederService.seed();
       Logger.log('User seeding completed successfully.', 'DatabaseModule');
     } catch (error) {
       Logger.error('Failed to seed users:', error, 'DatabaseModule');
     }
 
     try {
-      await this.accountSeederService.seed();
+      await this._accountSeederService.seed();
       Logger.log('Account seeding completed successfully.', 'DatabaseModule');
     } catch (error) {
       Logger.error('Failed to seed accounts:', error, 'DatabaseModule');

--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -19,7 +19,7 @@ export class DatabaseService {
    * @private
    * @readonly
    */
-  private static readonly requiredSeedTables = [
+  private static readonly _requiredSeedTables = [
     'user',
     'platform',
     'launcher',
@@ -29,9 +29,9 @@ export class DatabaseService {
   /**
    * Creates an instance of DatabaseService.
    *
-   * @param dataSource - The TypeORM DataSource for executing database queries.
+   * @param _dataSource - The TypeORM DataSource for executing database queries.
    */
-  constructor(private readonly dataSource: DataSource) {}
+  constructor(private readonly _dataSource: DataSource) {}
 
   /**
    * Verifies that the database is ready for seeding operations.
@@ -53,7 +53,7 @@ export class DatabaseService {
    * ```
    */
   async assertDatabaseReadyForSeeding(): Promise<void> {
-    const [databaseRow] = (await this.dataSource.query(
+    const [databaseRow] = (await this._dataSource.query(
       'SELECT current_database() AS "databaseName"',
     )) as Array<{ databaseName?: string }>;
 
@@ -63,7 +63,7 @@ export class DatabaseService {
       );
     }
 
-    const tableRows = (await this.dataSource.query(
+    const tableRows = (await this._dataSource.query(
       `SELECT table_name AS "tableName"
        FROM information_schema.tables
        WHERE table_schema = 'sto_info_app'
@@ -76,7 +76,7 @@ export class DatabaseService {
         .filter((tableName): tableName is string => Boolean(tableName)),
     );
 
-    const missingTables = DatabaseService.requiredSeedTables.filter(
+    const missingTables = DatabaseService._requiredSeedTables.filter(
       tableName => !existingTables.has(tableName),
     );
 
@@ -104,6 +104,6 @@ export class DatabaseService {
    * ```
    */
   async setDatabaseTimezone(): Promise<void> {
-    await this.dataSource.query("SET TIME ZONE 'UTC'");
+    await this._dataSource.query("SET TIME ZONE 'UTC'");
   }
 }

--- a/src/database/migrations/1782000000000-SeedStoInfoNewsPosts.ts
+++ b/src/database/migrations/1782000000000-SeedStoInfoNewsPosts.ts
@@ -11,7 +11,7 @@ export class SeedStoInfoNewsPosts1782000000000 implements MigrationInterface {
   /**
    * The STO Info posts to seed, oldest first. Bodies are authored as Markdown.
    */
-  private readonly posts: {
+  private readonly _posts: {
     slug: string;
     title: string;
     summary: string;
@@ -261,7 +261,7 @@ The app remains an ongoing community project, with future work planned around br
    * @param queryRunner - The TypeORM query runner.
    */
   public async up(queryRunner: QueryRunner): Promise<void> {
-    for (const post of this.posts) {
+    for (const post of this._posts) {
       await queryRunner.query(
         `
           INSERT INTO "sto_info_app"."news_post"
@@ -295,7 +295,7 @@ The app remains an ongoing community project, with future work planned around br
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `DELETE FROM "sto_info_app"."news_post" WHERE "slug" = ANY($1)`,
-      [this.posts.map(post => post.slug)],
+      [this._posts.map(post => post.slug)],
     );
   }
 }

--- a/src/database/migrations/1782086400000-SeedStoInfoEndeavourUpdateNewsPost.ts
+++ b/src/database/migrations/1782086400000-SeedStoInfoEndeavourUpdateNewsPost.ts
@@ -11,7 +11,7 @@ export class SeedStoInfoEndeavourUpdateNewsPost1782086400000 implements Migratio
   /**
    * The STO Info post to seed. Body is authored as Markdown.
    */
-  private readonly posts: {
+  private readonly _posts: {
     slug: string;
     title: string;
     summary: string;
@@ -74,7 +74,7 @@ This news post covers the following releases:
    * @param queryRunner - The TypeORM query runner.
    */
   public async up(queryRunner: QueryRunner): Promise<void> {
-    for (const post of this.posts) {
+    for (const post of this._posts) {
       await queryRunner.query(
         `
           INSERT INTO "sto_info_app"."news_post"
@@ -108,7 +108,7 @@ This news post covers the following releases:
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `DELETE FROM "sto_info_app"."news_post" WHERE "slug" = ANY($1)`,
-      [this.posts.map(post => post.slug)],
+      [this._posts.map(post => post.slug)],
     );
   }
 }

--- a/src/database/migrations/1782518400000-SeedStoInfoNewsAndNotificationsUpdate.ts
+++ b/src/database/migrations/1782518400000-SeedStoInfoNewsAndNotificationsUpdate.ts
@@ -10,7 +10,7 @@ export class SeedStoInfoNewsAndNotificationsUpdate1782518400000 implements Migra
   /**
    * The STO Info post to seed. Body is authored as Markdown.
    */
-  private readonly posts: {
+  private readonly _posts: {
     slug: string;
     title: string;
     summary: string;
@@ -71,7 +71,7 @@ This news post covers the following releases:
    * @param queryRunner - The TypeORM query runner.
    */
   public async up(queryRunner: QueryRunner): Promise<void> {
-    for (const post of this.posts) {
+    for (const post of this._posts) {
       await queryRunner.query(
         `
           INSERT INTO "sto_info_app"."news_post"
@@ -105,7 +105,7 @@ This news post covers the following releases:
   public async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
       `DELETE FROM "sto_info_app"."news_post" WHERE "slug" = ANY($1)`,
-      [this.posts.map(post => post.slug)],
+      [this._posts.map(post => post.slug)],
     );
   }
 }

--- a/src/database/user-seeder/user-seeder.service.ts
+++ b/src/database/user-seeder/user-seeder.service.ts
@@ -11,16 +11,16 @@ export class UserSeederService {
   /**
    * Creates an instance of UserSeederService.
    *
-   * @param userRepository - The user repository.
-   * @param userProfileRepository - The user profile repository.
+   * @param _userRepository - The user repository.
+   * @param _userProfileRepository - The user profile repository.
    * @param userService - The user service.
    */
   constructor(
     @InjectRepository(UserEntity)
-    private readonly userRepository: Repository<UserEntity>,
+    private readonly _userRepository: Repository<UserEntity>,
 
     @InjectRepository(UserProfileEntity)
-    private readonly userProfileRepository: Repository<UserProfileEntity>,
+    private readonly _userProfileRepository: Repository<UserProfileEntity>,
   ) {}
 
   /**
@@ -48,7 +48,7 @@ export class UserSeederService {
       process.env.DATASEED_USER_LASTNAME &&
       process.env.DATASEED_USER_PASSWORD
     ) {
-      const existingUser = await this.userRepository.findOne({
+      const existingUser = await this._userRepository.findOne({
         where: { email: process.env.DATASEED_USER_EMAIL },
         relations: { profile: true },
         withDeleted: true,
@@ -68,7 +68,7 @@ export class UserSeederService {
         );
         user.emailVerified = true;
 
-        const newUser = await this.userRepository.save(user);
+        const newUser = await this._userRepository.save(user);
 
         if (newUser) {
           const userProfile = new UserProfileEntity();
@@ -76,7 +76,7 @@ export class UserSeederService {
           userProfile.username = process.env.DATASEED_USER_USERNAME;
           userProfile.firstName = process.env.DATASEED_USER_FIRSTNAME;
           userProfile.lastName = process.env.DATASEED_USER_LASTNAME;
-          await this.userProfileRepository.save(userProfile);
+          await this._userProfileRepository.save(userProfile);
         }
       }
     }
@@ -89,7 +89,7 @@ export class UserSeederService {
    * @param existingUser - The matching soft-deleted user entity.
    */
   private async restoreSeededUser(existingUser: UserEntity): Promise<void> {
-    await this.userRepository.restore(existingUser.id);
+    await this._userRepository.restore(existingUser.id);
 
     existingUser.password = await bcrypt.hash(
       process.env.DATASEED_USER_PASSWORD!,
@@ -98,12 +98,12 @@ export class UserSeederService {
     existingUser.emailVerified = true;
     existingUser.deletedAt = null;
 
-    await this.userRepository.save(existingUser);
+    await this._userRepository.save(existingUser);
 
     const existingProfile = existingUser.profile;
 
     if (existingProfile?.deletedAt) {
-      await this.userProfileRepository.restore(existingUser.id);
+      await this._userProfileRepository.restore(existingUser.id);
     }
 
     const userProfile = existingProfile ?? new UserProfileEntity();
@@ -112,6 +112,6 @@ export class UserSeederService {
     userProfile.firstName = process.env.DATASEED_USER_FIRSTNAME!;
     userProfile.lastName = process.env.DATASEED_USER_LASTNAME!;
 
-    await this.userProfileRepository.save(userProfile);
+    await this._userProfileRepository.save(userProfile);
   }
 }

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -20,14 +20,14 @@ export interface EmailMessage {
 
 @Injectable()
 export class MailService {
-  private readonly logger = new Logger('MailService');
+  private readonly _logger = new Logger('MailService');
 
-  private readonly noReplyEmailFromSender: { name: string; email: string } = {
+  private readonly _noReplyEmailFromSender: { name: string; email: string } = {
     name: process.env.APP_TITLE!,
     email: process.env.EMAIL_NOREPLY_SENDER!,
   };
 
-  private readonly emailTemplatePath = path.join(
+  private readonly _emailTemplatePath = path.join(
     __dirname,
     '..',
     'views',
@@ -37,14 +37,14 @@ export class MailService {
   /**
    * Creates an instance of MailService.
    *
-   * @param secretsService - The secrets service.
-   * @param validatorsService - The validators service.
-   * @param mailerService - The mailer service.
+   * @param _secretsService - The secrets service.
+   * @param _validatorsService - The validators service.
+   * @param _mailerService - The mailer service.
    */
   constructor(
-    private readonly secretsService: SecretsService,
-    private readonly validatorsService: ValidatorsService,
-    private readonly mailerService: MailerService,
+    private readonly _secretsService: SecretsService,
+    private readonly _validatorsService: ValidatorsService,
+    private readonly _mailerService: MailerService,
   ) {
     this.validateEnvironmentVariables();
   }
@@ -85,7 +85,7 @@ export class MailService {
    * @returns A promise that resolves when primary initialisation is complete.
    */
   private async init() {
-    const secretObject = await this.secretsService.getSecret(
+    const secretObject = await this._secretsService.getSecret(
       process.env.AWS_SECRET_NAME!,
     );
 
@@ -103,7 +103,7 @@ export class MailService {
     templateData: any,
   ): Promise<{ emailHtmlContent: string; emailTextContent: string }> {
     const emailHtmlContent: string = await ejs.renderFile(
-      path.join(this.emailTemplatePath, templateName),
+      path.join(this._emailTemplatePath, templateName),
       templateData,
     );
     const emailTextContent: string = htmlToText(emailHtmlContent, {
@@ -287,7 +287,7 @@ export class MailService {
     try {
       await this.sendEmailViaSES(message);
     } catch (sesError) {
-      this.logger.warn(
+      this._logger.warn(
         'Amazon SES sending failed — falling back to SendGrid.',
         sesError instanceof Error ? sesError.message : String(sesError),
       );
@@ -324,7 +324,7 @@ export class MailService {
       },
     };
 
-    const result = (await this.mailerService.sendMail(mailOptions as any)) as {
+    const result = (await this._mailerService.sendMail(mailOptions as any)) as {
       rejected?: string[];
       pending?: string[];
       accepted?: string[];
@@ -359,9 +359,9 @@ export class MailService {
     } catch (error) {
       const err = error as any;
       if (err?.response?.body?.errors) {
-        this.logger.error(err.response.body.errors);
+        this._logger.error(err.response.body.errors);
       } else {
-        this.logger.error(err);
+        this._logger.error(err);
       }
     }
   }
@@ -393,7 +393,7 @@ export class MailService {
     if (!email) {
       return false;
     }
-    return this.validatorsService.validateEmail(email);
+    return this._validatorsService.validateEmail(email);
   }
 
   /**
@@ -422,7 +422,7 @@ export class MailService {
 
     return {
       to,
-      from: this.noReplyEmailFromSender,
+      from: this._noReplyEmailFromSender,
       subject: finalSubject,
       text,
       html,

--- a/src/news/news.controller.ts
+++ b/src/news/news.controller.ts
@@ -34,9 +34,9 @@ export class NewsController {
   /**
    * Creates an instance of NewsController.
    *
-   * @param newsService - The news service.
+   * @param _newsService - The news service.
    */
-  constructor(private readonly newsService: NewsService) {}
+  constructor(private readonly _newsService: NewsService) {}
 
   /**
    * Lists published news posts (public).
@@ -49,7 +49,7 @@ export class NewsController {
   @ApiOperation({ summary: 'List published news posts' })
   @ApiOkResponse({ description: 'A page of published posts.' })
   findPublished(@Query() query: NewsQueryDto) {
-    return this.newsService.findPublished(query);
+    return this._newsService.findPublished(query);
   }
 
   /**
@@ -64,7 +64,7 @@ export class NewsController {
   @Get('admin')
   @ApiOperation({ summary: 'List all news posts (admin)' })
   findAllForAdmin(@Query() query: NewsQueryDto) {
-    return this.newsService.findAllForAdmin(query);
+    return this._newsService.findAllForAdmin(query);
   }
 
   /**
@@ -79,7 +79,7 @@ export class NewsController {
   @Get('admin/:id')
   @ApiOperation({ summary: 'Get a news post by ID (admin)' })
   findOneForAdmin(@Param('id') id: string) {
-    return this.newsService.findOneById(id);
+    return this._newsService.findOneById(id);
   }
 
   /**
@@ -92,7 +92,7 @@ export class NewsController {
   @Get(':slug')
   @ApiOperation({ summary: 'Get a published news post by slug' })
   findOneBySlug(@Param('slug') slug: string) {
-    return this.newsService.findPublishedBySlug(slug);
+    return this._newsService.findPublishedBySlug(slug);
   }
 
   /**
@@ -108,7 +108,7 @@ export class NewsController {
   @Post()
   @ApiOperation({ summary: 'Create a news post (admin)' })
   create(@UserId() userId: string, @Body() dto: CreateNewsPostDto) {
-    return this.newsService.create(dto, userId);
+    return this._newsService.create(dto, userId);
   }
 
   /**
@@ -124,7 +124,7 @@ export class NewsController {
   @Patch(':id')
   @ApiOperation({ summary: 'Update a news post (admin)' })
   update(@Param('id') id: string, @Body() dto: UpdateNewsPostDto) {
-    return this.newsService.update(id, dto);
+    return this._newsService.update(id, dto);
   }
 
   /**
@@ -139,7 +139,7 @@ export class NewsController {
   @Post(':id/publish')
   @ApiOperation({ summary: 'Publish a news post (admin)' })
   publish(@Param('id') id: string) {
-    return this.newsService.publish(id);
+    return this._newsService.publish(id);
   }
 
   /**
@@ -154,6 +154,6 @@ export class NewsController {
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Delete a news post (admin)' })
   remove(@Param('id') id: string) {
-    return this.newsService.remove(id);
+    return this._newsService.remove(id);
   }
 }

--- a/src/news/news.service.ts
+++ b/src/news/news.service.ts
@@ -36,11 +36,11 @@ export class NewsService {
   /**
    * Creates an instance of NewsService.
    *
-   * @param newsRepository - The news post repository.
+   * @param _newsRepository - The news post repository.
    */
   constructor(
     @InjectRepository(NewsPostEntity)
-    private readonly newsRepository: Repository<NewsPostEntity>,
+    private readonly _newsRepository: Repository<NewsPostEntity>,
   ) {}
 
   /**
@@ -53,7 +53,7 @@ export class NewsService {
     const page = query.page && query.page > 0 ? query.page : 1;
     const pageSize = this.clampPageSize(query.pageSize);
 
-    const [items, total] = await this.newsRepository.findAndCount({
+    const [items, total] = await this._newsRepository.findAndCount({
       where: {
         status: NewsStatus.PUBLISHED,
         ...(query.category ? { category: query.category } : {}),
@@ -75,7 +75,7 @@ export class NewsService {
    * @returns A map of category to published post count.
    */
   private async countPublishedByCategory(): Promise<NewsCategoryCounts> {
-    const rows = await this.newsRepository
+    const rows = await this._newsRepository
       .createQueryBuilder('post')
       .select('post.category', 'category')
       .addSelect('COUNT(*)', 'count')
@@ -98,7 +98,7 @@ export class NewsService {
    * @throws NotFoundException when no published post matches the slug.
    */
   async findPublishedBySlug(slug: string): Promise<NewsPostEntity> {
-    const post = await this.newsRepository.findOne({
+    const post = await this._newsRepository.findOne({
       where: { slug, status: NewsStatus.PUBLISHED },
     });
 
@@ -123,7 +123,7 @@ export class NewsService {
     const page = query.page && query.page > 0 ? query.page : 1;
     const pageSize = this.clampPageSize(query.pageSize);
 
-    const [items, total] = await this.newsRepository.findAndCount({
+    const [items, total] = await this._newsRepository.findAndCount({
       where: query.category ? { category: query.category } : {},
       order: { status: 'ASC', publishedAt: 'DESC', createdAt: 'DESC' },
       skip: (page - 1) * pageSize,
@@ -141,7 +141,7 @@ export class NewsService {
    * @throws NotFoundException when no post matches the ID.
    */
   async findOneById(id: string): Promise<NewsPostEntity> {
-    const post = await this.newsRepository.findOne({ where: { id } });
+    const post = await this._newsRepository.findOne({ where: { id } });
 
     if (!post) {
       throw new NotFoundException('News post not found');
@@ -163,7 +163,7 @@ export class NewsService {
     authorId: string,
   ): Promise<NewsPostEntity> {
     const status = dto.status ?? NewsStatus.DRAFT;
-    const post = this.newsRepository.create({
+    const post = this._newsRepository.create({
       title: dto.title,
       slug: dto.slug?.trim() || this.slugify(dto.title),
       summary: dto.summary ?? null,
@@ -219,7 +219,7 @@ export class NewsService {
     const post = await this.findOneById(id);
     post.status = NewsStatus.PUBLISHED;
     post.publishedAt = post.publishedAt ?? new Date();
-    return this.newsRepository.save(post);
+    return this._newsRepository.save(post);
   }
 
   /**
@@ -230,7 +230,7 @@ export class NewsService {
    */
   async remove(id: string): Promise<void> {
     const post = await this.findOneById(id);
-    await this.newsRepository.softRemove(post);
+    await this._newsRepository.softRemove(post);
   }
 
   /**
@@ -257,7 +257,7 @@ export class NewsService {
     post: NewsPostEntity,
   ): Promise<NewsPostEntity> {
     try {
-      return await this.newsRepository.save(post);
+      return await this._newsRepository.save(post);
     } catch (error) {
       if (
         error instanceof QueryFailedError &&

--- a/src/notification/app-state.controller.ts
+++ b/src/notification/app-state.controller.ts
@@ -15,9 +15,9 @@ export class AppStateController {
   /**
    * Creates an instance of AppStateController.
    *
-   * @param notificationService - The notification service.
+   * @param _notificationService - The notification service.
    */
-  constructor(private readonly notificationService: NotificationService) {}
+  constructor(private readonly _notificationService: NotificationService) {}
 
   /**
    * Returns the polled application state in a single call: the active site
@@ -36,6 +36,6 @@ export class AppStateController {
   @ApiOperation({ summary: 'Get polled app state (banners + unread count)' })
   @ApiOkResponse({ description: 'Active banners and the caller unread count.' })
   getAppState(@OptionalUserId() userId: string | null) {
-    return this.notificationService.getAppState(userId);
+    return this._notificationService.getAppState(userId);
   }
 }

--- a/src/notification/notification.controller.ts
+++ b/src/notification/notification.controller.ts
@@ -35,9 +35,9 @@ export class NotificationController {
   /**
    * Creates an instance of NotificationController.
    *
-   * @param notificationService - The notification service.
+   * @param _notificationService - The notification service.
    */
-  constructor(private readonly notificationService: NotificationService) {}
+  constructor(private readonly _notificationService: NotificationService) {}
 
   // ----- Public -----
 
@@ -51,7 +51,7 @@ export class NotificationController {
   @ApiOperation({ summary: 'List active site banners' })
   @ApiOkResponse({ description: 'The active banners.' })
   findActiveBanners() {
-    return this.notificationService.findActiveBanners();
+    return this._notificationService.findActiveBanners();
   }
 
   // ----- Authenticated user inbox -----
@@ -68,7 +68,7 @@ export class NotificationController {
   @Get()
   @ApiOperation({ summary: 'Get the current user inbox' })
   getInbox(@UserId() userId: string, @Query() query: InboxQueryDto) {
-    return this.notificationService.getInbox(userId, query);
+    return this._notificationService.getInbox(userId, query);
   }
 
   /**
@@ -83,7 +83,7 @@ export class NotificationController {
   @ApiOperation({ summary: 'Get the current user unread count' })
   async getUnreadCount(@UserId() userId: string) {
     return {
-      unreadCount: await this.notificationService.getUnreadCount(userId),
+      unreadCount: await this._notificationService.getUnreadCount(userId),
     };
   }
 
@@ -98,7 +98,7 @@ export class NotificationController {
   @Post('read-all')
   @ApiOperation({ summary: 'Mark all notifications as read' })
   async markAllRead(@UserId() userId: string) {
-    return { marked: await this.notificationService.markAllRead(userId) };
+    return { marked: await this._notificationService.markAllRead(userId) };
   }
 
   /**
@@ -113,7 +113,7 @@ export class NotificationController {
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Mark a notification as read' })
   markRead(@UserId() userId: string, @Param('id') id: string) {
-    return this.notificationService.markRead(userId, id);
+    return this._notificationService.markRead(userId, id);
   }
 
   /**
@@ -128,7 +128,7 @@ export class NotificationController {
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Mark a notification as unread' })
   markUnread(@UserId() userId: string, @Param('id') id: string) {
-    return this.notificationService.markUnread(userId, id);
+    return this._notificationService.markUnread(userId, id);
   }
 
   // ----- Admin: banners -----
@@ -144,7 +144,7 @@ export class NotificationController {
   @Get('admin/banners')
   @ApiOperation({ summary: 'List all banners (admin)' })
   findAllBanners() {
-    return this.notificationService.findAllBanners();
+    return this._notificationService.findAllBanners();
   }
 
   /**
@@ -159,7 +159,7 @@ export class NotificationController {
   @Get('admin/banners/:id')
   @ApiOperation({ summary: 'Get a banner (admin)' })
   findBanner(@Param('id') id: string) {
-    return this.notificationService.findBannerById(id);
+    return this._notificationService.findBannerById(id);
   }
 
   /**
@@ -174,7 +174,7 @@ export class NotificationController {
   @Post('admin/banners')
   @ApiOperation({ summary: 'Create a banner (admin)' })
   createBanner(@Body() dto: CreateBannerDto) {
-    return this.notificationService.createBanner(dto);
+    return this._notificationService.createBanner(dto);
   }
 
   /**
@@ -190,7 +190,7 @@ export class NotificationController {
   @Patch('admin/banners/:id')
   @ApiOperation({ summary: 'Update a banner (admin)' })
   updateBanner(@Param('id') id: string, @Body() dto: UpdateBannerDto) {
-    return this.notificationService.updateBanner(id, dto);
+    return this._notificationService.updateBanner(id, dto);
   }
 
   /**
@@ -205,7 +205,7 @@ export class NotificationController {
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Delete a banner (admin)' })
   removeBanner(@Param('id') id: string) {
-    return this.notificationService.removeBanner(id);
+    return this._notificationService.removeBanner(id);
   }
 
   // ----- Admin: notifications -----
@@ -221,7 +221,7 @@ export class NotificationController {
   @Get('admin')
   @ApiOperation({ summary: 'List all notifications (admin)' })
   findAllNotifications() {
-    return this.notificationService.findAllNotifications();
+    return this._notificationService.findAllNotifications();
   }
 
   /**
@@ -236,7 +236,7 @@ export class NotificationController {
   @Post('admin')
   @ApiOperation({ summary: 'Create a notification (admin)' })
   createNotification(@Body() dto: CreateNotificationDto) {
-    return this.notificationService.createNotification(dto);
+    return this._notificationService.createNotification(dto);
   }
 
   /**
@@ -251,6 +251,6 @@ export class NotificationController {
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Delete a notification (admin)' })
   removeNotification(@Param('id') id: string) {
-    return this.notificationService.removeNotification(id);
+    return this._notificationService.removeNotification(id);
   }
 }

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -36,17 +36,17 @@ export class NotificationService {
   /**
    * Creates an instance of NotificationService.
    *
-   * @param bannerRepository - The banner repository.
-   * @param notificationRepository - The notification repository.
-   * @param notificationReadRepository - The per-user read-state repository.
+   * @param _bannerRepository - The banner repository.
+   * @param _notificationRepository - The notification repository.
+   * @param _notificationReadRepository - The per-user read-state repository.
    */
   constructor(
     @InjectRepository(BannerEntity)
-    private readonly bannerRepository: Repository<BannerEntity>,
+    private readonly _bannerRepository: Repository<BannerEntity>,
     @InjectRepository(NotificationEntity)
-    private readonly notificationRepository: Repository<NotificationEntity>,
+    private readonly _notificationRepository: Repository<NotificationEntity>,
     @InjectRepository(NotificationReadEntity)
-    private readonly notificationReadRepository: Repository<NotificationReadEntity>,
+    private readonly _notificationReadRepository: Repository<NotificationReadEntity>,
   ) {}
 
   // ----- Banners (public read) -----
@@ -58,7 +58,7 @@ export class NotificationService {
    */
   async findActiveBanners(): Promise<BannerEntity[]> {
     const now = new Date();
-    return this.bannerRepository
+    return this._bannerRepository
       .createQueryBuilder('b')
       .where('b.active = :active', { active: true })
       .andWhere('(b."startsAt" IS NULL OR b."startsAt" <= :now)', { now })
@@ -94,7 +94,7 @@ export class NotificationService {
    * @returns All banners.
    */
   findAllBanners(): Promise<BannerEntity[]> {
-    return this.bannerRepository.find({ order: { createdAt: 'DESC' } });
+    return this._bannerRepository.find({ order: { createdAt: 'DESC' } });
   }
 
   /**
@@ -105,7 +105,7 @@ export class NotificationService {
    * @throws NotFoundException when not found.
    */
   async findBannerById(id: string): Promise<BannerEntity> {
-    const banner = await this.bannerRepository.findOne({ where: { id } });
+    const banner = await this._bannerRepository.findOne({ where: { id } });
     if (!banner) {
       throw new NotFoundException('Banner not found');
     }
@@ -119,7 +119,7 @@ export class NotificationService {
    * @returns The created banner.
    */
   createBanner(dto: CreateBannerDto): Promise<BannerEntity> {
-    const banner = this.bannerRepository.create({
+    const banner = this._bannerRepository.create({
       severity: dto.severity,
       title: dto.title ?? null,
       message: dto.message,
@@ -130,7 +130,7 @@ export class NotificationService {
       startsAt: dto.startsAt ?? null,
       endsAt: dto.endsAt ?? null,
     });
-    return this.bannerRepository.save(banner);
+    return this._bannerRepository.save(banner);
   }
 
   /**
@@ -152,7 +152,7 @@ export class NotificationService {
     if (dto.active !== undefined) banner.active = dto.active;
     if (dto.startsAt !== undefined) banner.startsAt = dto.startsAt ?? null;
     if (dto.endsAt !== undefined) banner.endsAt = dto.endsAt ?? null;
-    return this.bannerRepository.save(banner);
+    return this._bannerRepository.save(banner);
   }
 
   /**
@@ -163,7 +163,7 @@ export class NotificationService {
    */
   async removeBanner(id: string): Promise<void> {
     const banner = await this.findBannerById(id);
-    await this.bannerRepository.softRemove(banner);
+    await this._bannerRepository.softRemove(banner);
   }
 
   // ----- Inbox notifications (user) -----
@@ -227,7 +227,7 @@ export class NotificationService {
    */
   async markRead(userId: string, notificationId: string): Promise<void> {
     await this.assertNotificationInScope(userId, notificationId);
-    await this.notificationReadRepository
+    await this._notificationReadRepository
       .createQueryBuilder()
       .insert()
       .values({ notificationId, userId })
@@ -244,7 +244,7 @@ export class NotificationService {
    */
   async markUnread(userId: string, notificationId: string): Promise<void> {
     await this.assertNotificationInScope(userId, notificationId);
-    await this.notificationReadRepository.delete({ notificationId, userId });
+    await this._notificationReadRepository.delete({ notificationId, userId });
   }
 
   /**
@@ -262,7 +262,7 @@ export class NotificationService {
       return 0;
     }
 
-    await this.notificationReadRepository
+    await this._notificationReadRepository
       .createQueryBuilder()
       .insert()
       .values(unread.map(n => ({ notificationId: n.id, userId })))
@@ -282,7 +282,7 @@ export class NotificationService {
    */
   createNotification(dto: CreateNotificationDto): Promise<NotificationEntity> {
     const target = dto.target ?? NotificationTarget.BROADCAST;
-    const notification = this.notificationRepository.create({
+    const notification = this._notificationRepository.create({
       target,
       userId: target === NotificationTarget.USER ? (dto.userId ?? null) : null,
       severity: dto.severity,
@@ -290,7 +290,7 @@ export class NotificationService {
       body: dto.body,
       linkUrl: dto.linkUrl ?? null,
     });
-    return this.notificationRepository.save(notification);
+    return this._notificationRepository.save(notification);
   }
 
   /**
@@ -299,7 +299,7 @@ export class NotificationService {
    * @returns All notifications.
    */
   findAllNotifications(): Promise<NotificationEntity[]> {
-    return this.notificationRepository.find({ order: { createdAt: 'DESC' } });
+    return this._notificationRepository.find({ order: { createdAt: 'DESC' } });
   }
 
   /**
@@ -309,13 +309,13 @@ export class NotificationService {
    * @throws NotFoundException when not found.
    */
   async removeNotification(id: string): Promise<void> {
-    const notification = await this.notificationRepository.findOne({
+    const notification = await this._notificationRepository.findOne({
       where: { id },
     });
     if (!notification) {
       throw new NotFoundException('Notification not found');
     }
-    await this.notificationRepository.softRemove(notification);
+    await this._notificationRepository.softRemove(notification);
   }
 
   // ----- Helpers -----
@@ -328,7 +328,7 @@ export class NotificationService {
    * @returns A configured query builder.
    */
   private scopedInboxQuery(userId: string) {
-    return this.notificationRepository
+    return this._notificationRepository
       .createQueryBuilder('n')
       .leftJoin(
         NotificationReadEntity,

--- a/src/shared/secrets/secrets.service.ts
+++ b/src/shared/secrets/secrets.service.ts
@@ -6,15 +6,15 @@ import { Injectable, Logger } from '@nestjs/common';
 
 @Injectable()
 export class SecretsService {
-  private readonly secretsManager: SecretsManagerClient;
+  private readonly _secretsManager: SecretsManagerClient;
   private cache: { [key: string]: any } = {};
-  private readonly logger = new Logger(SecretsService.name);
+  private readonly _logger = new Logger(SecretsService.name);
 
   /**
    * Creates an instance of SecretsService and initialises the AWS Secrets Manager client.
    */
   constructor() {
-    this.secretsManager = new SecretsManagerClient({
+    this._secretsManager = new SecretsManagerClient({
       region: process.env.AWS_REGION,
     });
   }
@@ -37,7 +37,7 @@ export class SecretsService {
 
       // If it's not in the cache, retrieve it
       const command = new GetSecretValueCommand({ SecretId: secretName });
-      const data = await this.secretsManager.send(command);
+      const data = await this._secretsManager.send(command);
 
       if (!('SecretString' in data) || !data.SecretString) {
         return undefined;
@@ -50,7 +50,7 @@ export class SecretsService {
       return secretObject;
     } catch (err: unknown) {
       const stack = err instanceof Error ? err.stack : undefined;
-      this.logger.error(`Failed to get secret ${secretName}`, stack);
+      this._logger.error(`Failed to get secret ${secretName}`, stack);
       throw err;
     }
   }

--- a/src/shared/utilities/image-uploads.service.ts
+++ b/src/shared/utilities/image-uploads.service.ts
@@ -18,9 +18,9 @@ import { ensureError, stringifyError } from './error.utility';
 
 @Injectable()
 export class ImageUploadsService {
-  private readonly logger = new Logger(ImageUploadsService.name);
-  private readonly bucketName: string;
-  private readonly environment: string;
+  private readonly _logger = new Logger(ImageUploadsService.name);
+  private readonly _bucketName: string;
+  private readonly _environment: string;
   private cloudmersiveApiKey: string;
   private cloudflareImagesAccountId: string;
   private cloudflareImagesApiKey: string;
@@ -28,19 +28,19 @@ export class ImageUploadsService {
   /**
    * Creates an instance of ImageUploadsService.
    *
-   * @param secretsService - The secrets service.
-   * @param configService - The config service.
-   * @param s3Client - The s3 client.
+   * @param _secretsService - The secrets service.
+   * @param _configService - The config service.
+   * @param _s3Client - The s3 client.
    */
   constructor(
-    private readonly secretsService: SecretsService,
-    private readonly configService: ConfigService,
-    private readonly s3Client: S3Client,
+    private readonly _secretsService: SecretsService,
+    private readonly _configService: ConfigService,
+    private readonly _s3Client: S3Client,
   ) {
-    this.bucketName = this.configService.get<string>(
+    this._bucketName = this._configService.get<string>(
       'CLOUDFLARE_R2_BUCKET_NAME',
     )!;
-    this.environment = this.configService.get<string>('NODE_ENV')!;
+    this._environment = this._configService.get<string>('NODE_ENV')!;
   }
 
   /**
@@ -59,7 +59,7 @@ export class ImageUploadsService {
    * @returns A promise that resolves when initialisation is complete.
    */
   private async init() {
-    const secretObject = await this.secretsService.getSecret(
+    const secretObject = await this._secretsService.getSecret(
       process.env.AWS_SECRET_NAME!,
     );
 
@@ -97,7 +97,7 @@ export class ImageUploadsService {
    * @returns A promise that resolves if the file is clean.
    */
   private async scanFileForViruses(fileBuffer: Buffer): Promise<void> {
-    this.logger.debug(
+    this._logger.debug(
       `[scanFileForViruses] Starting virus scan - BufferSize: ${fileBuffer.length} bytes`,
     );
 
@@ -133,7 +133,7 @@ export class ImageUploadsService {
           (v: Cloudmersive.VirusFound) => v.VirusName,
         ).join(', ');
 
-        this.logger.error(
+        this._logger.error(
           `[scanFileForViruses] Viruses detected: ${virusNames}`,
         );
         throw new BadRequestException(
@@ -141,11 +141,11 @@ export class ImageUploadsService {
         );
       }
 
-      this.logger.debug(
+      this._logger.debug(
         '[scanFileForViruses] Virus scan passed - No threats found',
       );
     } catch (error: unknown) {
-      this.logger.error(
+      this._logger.error(
         `[scanFileForViruses] Virus scan failed - Error: ${(error as Error).message}`,
         (error as Error).stack,
       );
@@ -166,7 +166,7 @@ export class ImageUploadsService {
     file: Express.Multer.File,
     characterId?: string,
   ) {
-    this.logger.debug(
+    this._logger.debug(
       `[uploadImageToCloudflareR2] Starting upload - UserId: ${userId}, CharacterId: ${characterId}, FileName: ${file?.originalname}, FileSize: ${file?.size} bytes`,
     );
 
@@ -176,31 +176,31 @@ export class ImageUploadsService {
         file,
       );
 
-      this.logger.debug(
+      this._logger.debug(
         `[uploadImageToCloudflareR2] File validated - OriginalName: ${file.originalname}, SafeName: ${safeFileName}, BufferSize: ${fileBuffer.length} bytes`,
       );
 
       // Prepare the Cloudflare key (path and filename within the bucket)
       const folderPath = characterId ? `${userId}/${characterId}` : userId;
-      const fileKey = `${this.environment}/${folderPath}/${safeFileName}`;
+      const fileKey = `${this._environment}/${folderPath}/${safeFileName}`;
 
-      this.logger.debug(
-        `[uploadImageToCloudflareR2] Prepared for R2 - FileKey: ${fileKey}, Bucket: ${this.bucketName}`,
+      this._logger.debug(
+        `[uploadImageToCloudflareR2] Prepared for R2 - FileKey: ${fileKey}, Bucket: ${this._bucketName}`,
       );
 
       // Prepare the command to upload the file to R2
       const command = new PutObjectCommand({
-        Bucket: this.bucketName,
+        Bucket: this._bucketName,
         Key: fileKey,
         Body: fileBuffer,
         ContentType: file.mimetype,
       });
 
       // Upload to Cloudflare R2
-      this.logger.debug('[uploadImageToCloudflareR2] Sending to R2...');
-      await this.s3Client.send(command);
+      this._logger.debug('[uploadImageToCloudflareR2] Sending to R2...');
+      await this._s3Client.send(command);
 
-      this.logger.log(
+      this._logger.log(
         `[uploadImageToCloudflareR2] Successfully uploaded to R2 - FileKey: ${fileKey}`,
       );
 
@@ -209,7 +209,7 @@ export class ImageUploadsService {
       const message = stringifyError(error);
 
       const stack = error instanceof Error ? error.stack : undefined;
-      this.logger.error(
+      this._logger.error(
         `[uploadImageToCloudflareR2] Upload failed - UserId: ${userId}, CharacterId: ${characterId}, Error: ${message}`,
         stack,
       );
@@ -239,11 +239,11 @@ export class ImageUploadsService {
     );
 
     const command = new DeleteObjectCommand({
-      Bucket: this.bucketName,
+      Bucket: this._bucketName,
       Key: fileKey,
     });
 
-    await this.s3Client.send(command);
+    await this._s3Client.send(command);
 
     return fileKey;
   }
@@ -263,7 +263,7 @@ export class ImageUploadsService {
     entityType?: string,
     entityId?: string,
   ) {
-    this.logger.debug(
+    this._logger.debug(
       `[uploadImageToCloudflareImages] Starting upload - UserId: ${userId}, EntityType: ${entityType || 'none'}, EntityId: ${entityId || 'none'}, FileName: ${file?.originalname}`,
     );
 
@@ -282,7 +282,7 @@ export class ImageUploadsService {
 
     const customId = this.buildCloudflareCustomId(userId, entityType, entityId);
 
-    this.logger.debug(
+    this._logger.debug(
       `[uploadImageToCloudflareImages] Generated custom ID: ${customId}`,
     );
 
@@ -293,7 +293,7 @@ export class ImageUploadsService {
     const metadata = {
       userId,
       originalFileName: safeFileName,
-      env: this.environment,
+      env: this._environment,
       uploadedAt: new Date().toISOString(),
       ...(entityType && { entityType }),
       ...(entityId && { entityId }),
@@ -301,7 +301,7 @@ export class ImageUploadsService {
 
     formData.append('metadata', JSON.stringify(metadata));
 
-    this.logger.debug(
+    this._logger.debug(
       `[uploadImageToCloudflareImages] Metadata: ${JSON.stringify(metadata)}`,
     );
 
@@ -323,7 +323,7 @@ export class ImageUploadsService {
         errorMsgFailedUpload,
       );
 
-      this.logger.log(
+      this._logger.log(
         `[uploadImageToCloudflareImages] Successfully uploaded - ImageId: ${imageId}`,
       );
 
@@ -333,7 +333,7 @@ export class ImageUploadsService {
 
       const errorDetails = this.getCloudflareUploadErrorDetails(error);
 
-      this.logger.error(
+      this._logger.error(
         `[uploadImageToCloudflareImages] Upload failed - Error: ${errorMessage}`,
         errorDetails,
       );
@@ -356,7 +356,7 @@ export class ImageUploadsService {
   ): string {
     // Format: env-userId-entityType-entityId-timestamp
     const timestamp = Date.now();
-    const parts = [this.environment, userId];
+    const parts = [this._environment, userId];
     if (entityType) {
       parts.push(entityType);
     }
@@ -379,7 +379,7 @@ export class ImageUploadsService {
     errorMsgFailedUpload: string,
   ): string {
     if (!response || typeof response !== 'object') {
-      this.logger.error(
+      this._logger.error(
         '[uploadImageToCloudflareImages] Response is missing or invalid',
       );
       throw new BadRequestException(errorMsgFailedUpload);
@@ -387,7 +387,7 @@ export class ImageUploadsService {
 
     const status = (response as { status?: unknown }).status;
     if (status !== 200) {
-      this.logger.error(
+      this._logger.error(
         `[uploadImageToCloudflareImages] Upload failed with status ${stringifyError(status)}`,
       );
 
@@ -396,14 +396,14 @@ export class ImageUploadsService {
 
     const data = (response as { data?: any }).data;
     if (!data) {
-      this.logger.error(
+      this._logger.error(
         '[uploadImageToCloudflareImages] Response data is missing',
       );
       throw new BadRequestException(errorMsgFailedUpload);
     }
 
     if (!data.result) {
-      this.logger.error(
+      this._logger.error(
         '[uploadImageToCloudflareImages] Response result is missing',
       );
       throw new BadRequestException(errorMsgFailedUpload);
@@ -411,7 +411,7 @@ export class ImageUploadsService {
 
     const id = data.result.id as unknown;
     if (typeof id !== 'string' || id.length === 0) {
-      this.logger.error(
+      this._logger.error(
         '[uploadImageToCloudflareImages] Response result ID is missing',
       );
       throw new BadRequestException(errorMsgFailedUpload);
@@ -480,28 +480,28 @@ export class ImageUploadsService {
     userId: string,
     file: Express.Multer.File,
   ): Promise<{ fileBuffer: Buffer; safeFileName: string }> {
-    this.logger.debug(
+    this._logger.debug(
       `[validateAndSanitiseFile] Starting validation - UserId: ${userId}, FileName: ${file?.originalname}, FileSize: ${file?.size} bytes, MimeType: ${file?.mimetype}`,
     );
 
     if (!userId) {
-      this.logger.error('[validateAndSanitiseFile] User ID is missing');
+      this._logger.error('[validateAndSanitiseFile] User ID is missing');
       throw new BadRequestException('User ID is missing');
     }
 
     if (!file) {
-      this.logger.error('[validateAndSanitiseFile] File is missing');
+      this._logger.error('[validateAndSanitiseFile] File is missing');
       throw new BadRequestException('File is missing');
     }
 
     if (!file.mimetype) {
-      this.logger.error('[validateAndSanitiseFile] File mimetype is missing');
+      this._logger.error('[validateAndSanitiseFile] File mimetype is missing');
       throw new BadRequestException('File mimetype is missing');
     }
 
     // Validate file type and size (allow only jpeg, jpg, or png)
     if (!['image/jpeg', 'image/jpg', 'image/png'].includes(file.mimetype)) {
-      this.logger.error(
+      this._logger.error(
         `[validateAndSanitiseFile] Invalid mimetype - MimeType: ${file.mimetype}`,
       );
       throw new BadRequestException(
@@ -511,30 +511,30 @@ export class ImageUploadsService {
 
     const maxSize = +process.env.MAX_IMAGE_SIZE_IN_BYTES!;
     if (file.size > maxSize) {
-      this.logger.error(
+      this._logger.error(
         `[validateAndSanitiseFile] File too large - Size: ${file.size} bytes, MaxSize: ${maxSize} bytes`,
       );
       throw new BadRequestException('File too large');
     }
 
     if (!file.buffer) {
-      this.logger.error('[validateAndSanitiseFile] File buffer is missing');
+      this._logger.error('[validateAndSanitiseFile] File buffer is missing');
       throw new BadRequestException('File buffer is missing');
     }
 
     if (!file.filename && !file.originalname) {
-      this.logger.error('[validateAndSanitiseFile] File name is missing');
+      this._logger.error('[validateAndSanitiseFile] File name is missing');
       throw new BadRequestException('File name is missing');
     }
 
     const fileBuffer = file.buffer;
 
     if (!fileBuffer || fileBuffer.length === 0) {
-      this.logger.error('[validateAndSanitiseFile] No image data provided');
+      this._logger.error('[validateAndSanitiseFile] No image data provided');
       throw new BadRequestException('No image data provided');
     }
 
-    this.logger.debug(
+    this._logger.debug(
       `[validateAndSanitiseFile] File structure validated - BufferSize: ${fileBuffer.length} bytes`,
     );
 
@@ -549,13 +549,13 @@ export class ImageUploadsService {
     );
     /* istanbul ignore next */
     if (!SAFE_FILENAME_PATTERN.test(safeFileName)) {
-      this.logger.error(
+      this._logger.error(
         `[validateAndSanitiseFile] Invalid characters in filename - OriginalName: ${originalFileName}, SafeName: ${safeFileName}`,
       );
       throw new BadRequestException('Invalid characters in file name');
     }
 
-    this.logger.debug(
+    this._logger.debug(
       `[validateAndSanitiseFile] Validation complete - OriginalName: ${originalFileName}, SafeName: ${safeFileName}`,
     );
 

--- a/src/sto/account/account.controller.ts
+++ b/src/sto/account/account.controller.ts
@@ -31,9 +31,9 @@ export class AccountController {
   /**
    * Creates an instance of AccountController.
    *
-   * @param accountService - The account service.
+   * @param _accountService - The account service.
    */
-  constructor(private readonly accountService: AccountService) {}
+  constructor(private readonly _accountService: AccountService) {}
 
   /**
    * Creates a new STO account for the authenticated user.
@@ -54,7 +54,7 @@ export class AccountController {
       userId,
     };
 
-    return this.accountService.create(account);
+    return this._accountService.create(account);
   }
 
   /**
@@ -70,7 +70,7 @@ export class AccountController {
   })
   @HttpCode(HttpStatus.OK)
   findAllUsersAccounts(@UserId() userId: string) {
-    return this.accountService.findAllUsersAccounts(userId);
+    return this._accountService.findAllUsersAccounts(userId);
   }
 
   /**
@@ -84,7 +84,7 @@ export class AccountController {
   @ApiOkResponse({ description: 'Successfully found the account.' })
   @ApiBadRequestResponse({ description: 'Failed to find the account.' })
   findOne(@UserId() userId: string, @Param('id') id: string) {
-    return this.accountService.findOneForUser(id, userId);
+    return this._accountService.findOneForUser(id, userId);
   }
 
   /**
@@ -103,7 +103,7 @@ export class AccountController {
     @Param('id') id: string,
     @Body() updateAccountDto: UpdateAccountDto,
   ) {
-    return this.accountService.updateForUser(id, userId, updateAccountDto);
+    return this._accountService.updateForUser(id, userId, updateAccountDto);
   }
 
   /**
@@ -116,6 +116,6 @@ export class AccountController {
   @ApiOkResponse({ description: 'Successfully removed the account.' })
   @ApiBadRequestResponse({ description: 'Failed to remove the account.' })
   remove(@UserId() userId: string, @Param('id') id: string) {
-    return this.accountService.removeForUser(id, userId);
+    return this._accountService.removeForUser(id, userId);
   }
 }

--- a/src/sto/account/account.service.ts
+++ b/src/sto/account/account.service.ts
@@ -27,20 +27,20 @@ export type AccountListItem = AccountEntity & {
 
 @Injectable()
 export class AccountService {
-  private static readonly fallbackAccountTypeImageId =
+  private static readonly _fallbackAccountTypeImageId =
     '8ab52131-6f11-408a-d9df-3c1acaa46d00';
 
   /**
    * Creates an instance of AccountService.
    *
-   * @param accountRepository - The account repository.
-   * @param platformLauncherRepository - The platform-launcher repository.
+   * @param _accountRepository - The account repository.
+   * @param _platformLauncherRepository - The platform-launcher repository.
    */
   constructor(
     @InjectRepository(AccountEntity)
-    private readonly accountRepository: Repository<AccountEntity>,
+    private readonly _accountRepository: Repository<AccountEntity>,
     @InjectRepository(PlatformLauncherEntity)
-    private readonly platformLauncherRepository: Repository<PlatformLauncherEntity>,
+    private readonly _platformLauncherRepository: Repository<PlatformLauncherEntity>,
   ) {}
 
   /**
@@ -127,7 +127,7 @@ export class AccountService {
     }
 
     return buildCloudflareImageUrl(
-      AccountService.fallbackAccountTypeImageId,
+      AccountService._fallbackAccountTypeImageId,
       'public',
     );
   }
@@ -158,7 +158,7 @@ export class AccountService {
       where.id = Not(excludeAccountId);
     }
 
-    const existing = await this.accountRepository.findOne({ where });
+    const existing = await this._accountRepository.findOne({ where });
     if (existing) {
       throw new ConflictException('Handle already exists');
     }
@@ -189,14 +189,14 @@ export class AccountService {
     const handleNormalized = this.normalizeHandle(createAccountDto.handle);
     const handleSlug = this.generateSlug(createAccountDto.handle);
 
-    const newAccount = this.accountRepository.create({
+    const newAccount = this._accountRepository.create({
       ...createAccountDto,
       handleNormalized,
       handleSlug,
     });
 
     try {
-      await this.accountRepository.save(newAccount);
+      await this._accountRepository.save(newAccount);
       return newAccount;
     } catch (error: unknown) {
       throw new InternalServerErrorException('Failed to save a new account', {
@@ -216,7 +216,7 @@ export class AccountService {
       throw new BadRequestException('User ID is required');
     }
 
-    const accounts = await this.accountRepository.find({
+    const accounts = await this._accountRepository.find({
       where: {
         user: {
           id: userId,
@@ -229,7 +229,7 @@ export class AccountService {
       order: { handle: 'ASC', username: 'ASC', createdAt: 'ASC' },
     });
 
-    const platformLaunchers = await this.platformLauncherRepository.find({
+    const platformLaunchers = await this._platformLauncherRepository.find({
       select: {
         platformId: true,
         launcherId: true,
@@ -272,7 +272,7 @@ export class AccountService {
       throw new BadRequestException('Account ID is required');
     }
 
-    const account = await this.accountRepository.findOne({
+    const account = await this._accountRepository.findOne({
       where: {
         id: id,
       },
@@ -291,7 +291,7 @@ export class AccountService {
       throw new BadRequestException('Handle slug is required');
     }
 
-    return this.accountRepository.findOne({
+    return this._accountRepository.findOne({
       where: { handleSlug },
     });
   }
@@ -309,7 +309,7 @@ export class AccountService {
     id: string,
     userId: string,
   ): Promise<AccountEntity> {
-    const account = await this.accountRepository.findOne({
+    const account = await this._accountRepository.findOne({
       where: {
         id,
       },
@@ -369,8 +369,8 @@ export class AccountService {
       throw new BadRequestException('Update data is required');
     }
 
-    await this.accountRepository.update(id, updateAccountDto);
-    const updatedAccount = await this.accountRepository.findOne({
+    await this._accountRepository.update(id, updateAccountDto);
+    const updatedAccount = await this._accountRepository.findOne({
       where: {
         id: id,
       },
@@ -428,7 +428,7 @@ export class AccountService {
     }
 
     Object.assign(account, updateAccountDto);
-    await this.accountRepository.save(account);
+    await this._accountRepository.save(account);
     return account;
   }
 
@@ -445,7 +445,7 @@ export class AccountService {
       throw new BadRequestException('Account ID is required');
     }
 
-    const deleteResponse = await this.accountRepository.softDelete(id);
+    const deleteResponse = await this._accountRepository.softDelete(id);
     if (!deleteResponse.affected) {
       throw new NotFoundException(`Account with ID "${id}" not found`);
     }
@@ -469,7 +469,7 @@ export class AccountService {
     }
 
     const account = await this.requireOwnedAccount(id, userId);
-    const deleteResponse = await this.accountRepository.softDelete(account.id);
+    const deleteResponse = await this._accountRepository.softDelete(account.id);
     if (!deleteResponse.affected) {
       throw new NotFoundException(`Account with ID "${id}" not found`);
     }
@@ -481,7 +481,7 @@ export class AccountService {
    * @returns Accounts, with soft-deleted rows included.
    */
   async findAllSoftDeleted(): Promise<AccountEntity[]> {
-    return this.accountRepository.find({ withDeleted: true });
+    return this._accountRepository.find({ withDeleted: true });
   }
 
   /**
@@ -491,6 +491,6 @@ export class AccountService {
    */
   async hardDeleteOlderThanOneWeek(): Promise<void> {
     const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
-    await this.accountRepository.delete({ deletedAt: LessThan(sevenDaysAgo) });
+    await this._accountRepository.delete({ deletedAt: LessThan(sevenDaysAgo) });
   }
 }

--- a/src/sto/character/character.controller.ts
+++ b/src/sto/character/character.controller.ts
@@ -43,14 +43,14 @@ import { UpdateCharacterDto } from './dto/update-character.dto';
 @UseGuards(JwtAuthGuard)
 @Controller('character')
 export class CharacterController {
-  private readonly logger = new Logger(CharacterController.name);
+  private readonly _logger = new Logger(CharacterController.name);
 
   /**
    * Creates an instance of CharacterController.
    *
-   * @param characterService - The character service.
+   * @param _characterService - The character service.
    */
-  constructor(private readonly characterService: CharacterService) {}
+  constructor(private readonly _characterService: CharacterService) {}
 
   /**
    * Filter for image file uploads.
@@ -123,28 +123,28 @@ export class CharacterController {
     @Param('id') id: string,
     @UploadedFile() file: Express.Multer.File,
   ) {
-    this.logger.debug(
+    this._logger.debug(
       `[uploadProfileImage] Request received - UserId: ${userId}, CharacterId: ${id}`,
     );
 
     if (!file) {
-      this.logger.error(
+      this._logger.error(
         `[uploadProfileImage] No file provided - UserId: ${userId}, CharacterId: ${id}`,
       );
       throw new BadRequestException('Image file is required');
     }
 
-    this.logger.debug(
+    this._logger.debug(
       `[uploadProfileImage] File metadata - Name: ${file.originalname}, Size: ${file.size} bytes, MimeType: ${file.mimetype}`,
     );
 
     try {
-      const result = await this.characterService.uploadProfileImage(
+      const result = await this._characterService.uploadProfileImage(
         id,
         userId,
         file,
       );
-      this.logger.log(
+      this._logger.log(
         `[uploadProfileImage] Successfully uploaded image - UserId: ${userId}, CharacterId: ${id}`,
       );
       return result;
@@ -152,7 +152,7 @@ export class CharacterController {
       const message = stringifyError(error);
 
       const stack = error instanceof Error ? error.stack : undefined;
-      this.logger.error(
+      this._logger.error(
         `[uploadProfileImage] Failed to upload image - UserId: ${userId}, CharacterId: ${id}, Error: ${message}`,
         stack,
       );
@@ -174,7 +174,7 @@ export class CharacterController {
     @UserId() userId: string,
     @Body() createCharacterDto: CreateCharacterRequestDto,
   ) {
-    return this.characterService.create(createCharacterDto, userId);
+    return this._characterService.create(createCharacterDto, userId);
   }
 
   /**
@@ -190,7 +190,7 @@ export class CharacterController {
     @UserId() userId: string,
     @Query('accountId') accountId: string,
   ) {
-    return this.characterService.findAllForAccount(accountId, userId);
+    return this._characterService.findAllForAccount(accountId, userId);
   }
 
   /**
@@ -204,7 +204,7 @@ export class CharacterController {
   @ApiOkResponse({ description: 'Successfully found the character.' })
   @ApiBadRequestResponse({ description: 'Failed to find the character.' })
   findOne(@UserId() userId: string, @Param('id') id: string) {
-    return this.characterService.findOneForUser(id, userId);
+    return this._characterService.findOneForUser(id, userId);
   }
 
   /**
@@ -223,7 +223,7 @@ export class CharacterController {
     @Param('id') id: string,
     @Body() updateCharacterDto: UpdateCharacterDto,
   ) {
-    return this.characterService.updateForUser(id, userId, updateCharacterDto);
+    return this._characterService.updateForUser(id, userId, updateCharacterDto);
   }
 
   /**
@@ -236,7 +236,7 @@ export class CharacterController {
   @ApiOkResponse({ description: 'Successfully removed the character.' })
   @ApiBadRequestResponse({ description: 'Failed to remove the character.' })
   remove(@UserId() userId: string, @Param('id') id: string) {
-    return this.characterService.removeForUser(id, userId);
+    return this._characterService.removeForUser(id, userId);
   }
 
   /**
@@ -248,7 +248,7 @@ export class CharacterController {
   @Get('lookup/general-factions')
   @ApiOkResponse({ description: 'Successfully retrieved general factions.' })
   getGeneralFactions(@Query('factionId') factionId?: string) {
-    return this.characterService.getGeneralFactions(factionId);
+    return this._characterService.getGeneralFactions(factionId);
   }
 
   /**
@@ -260,7 +260,7 @@ export class CharacterController {
   @Get('lookup/factions')
   @ApiOkResponse({ description: 'Successfully retrieved factions.' })
   getFactions(@Query('generalFactionId') generalFactionId?: string) {
-    return this.characterService.getFactions(generalFactionId);
+    return this._characterService.getFactions(generalFactionId);
   }
 
   /**
@@ -271,7 +271,7 @@ export class CharacterController {
   @Get('lookup/sexes')
   @ApiOkResponse({ description: 'Successfully retrieved sexes.' })
   getSexes() {
-    return this.characterService.getSexes();
+    return this._characterService.getSexes();
   }
 
   /**
@@ -282,7 +282,7 @@ export class CharacterController {
   @Get('lookup/classes')
   @ApiOkResponse({ description: 'Successfully retrieved classes.' })
   getClasses() {
-    return this.characterService.getClasses();
+    return this._characterService.getClasses();
   }
 
   /**
@@ -294,7 +294,7 @@ export class CharacterController {
   @Get('lookup/recruit-types')
   @ApiOkResponse({ description: 'Successfully retrieved recruit types.' })
   getRecruitTypes(@Query('factionId') factionId?: string) {
-    return this.characterService.getRecruitTypes(factionId);
+    return this._characterService.getRecruitTypes(factionId);
   }
 
   /**
@@ -310,6 +310,6 @@ export class CharacterController {
     @Query('factionId') factionId?: string,
     @Query('recruitTypeId') recruitTypeId?: string,
   ) {
-    return this.characterService.getSpecies(factionId, recruitTypeId);
+    return this._characterService.getSpecies(factionId, recruitTypeId);
   }
 }

--- a/src/sto/character/character.service.ts
+++ b/src/sto/character/character.service.ts
@@ -26,39 +26,39 @@ import { SpeciesEntity } from './entities/species.entity';
 
 @Injectable()
 export class CharacterService {
-  private readonly logger = new Logger(CharacterService.name);
+  private readonly _logger = new Logger(CharacterService.name);
 
   /**
    * Creates an instance of CharacterService.
    *
-   * @param characterRepository - The character repository.
-   * @param accountRepository - The account repository.
-   * @param generalFactionRepository - The general faction repository.
-   * @param factionRepository - The faction repository.
-   * @param sexRepository - The sex repository.
-   * @param classRepository - The class repository.
-   * @param recruitTypeRepository - The recruit type repository.
-   * @param speciesRepository - The species repository.
-   * @param imageUploadsService - The image uploads service.
+   * @param _characterRepository - The character repository.
+   * @param _accountRepository - The account repository.
+   * @param _generalFactionRepository - The general faction repository.
+   * @param _factionRepository - The faction repository.
+   * @param _sexRepository - The sex repository.
+   * @param _classRepository - The class repository.
+   * @param _recruitTypeRepository - The recruit type repository.
+   * @param _speciesRepository - The species repository.
+   * @param _imageUploadsService - The image uploads service.
    */
   constructor(
     @InjectRepository(CharacterEntity)
-    private readonly characterRepository: Repository<CharacterEntity>,
+    private readonly _characterRepository: Repository<CharacterEntity>,
     @InjectRepository(AccountEntity)
-    private readonly accountRepository: Repository<AccountEntity>,
+    private readonly _accountRepository: Repository<AccountEntity>,
     @InjectRepository(GeneralFactionEntity)
-    private readonly generalFactionRepository: Repository<GeneralFactionEntity>,
+    private readonly _generalFactionRepository: Repository<GeneralFactionEntity>,
     @InjectRepository(FactionEntity)
-    private readonly factionRepository: Repository<FactionEntity>,
+    private readonly _factionRepository: Repository<FactionEntity>,
     @InjectRepository(SexEntity)
-    private readonly sexRepository: Repository<SexEntity>,
+    private readonly _sexRepository: Repository<SexEntity>,
     @InjectRepository(CharacterClassEntity)
-    private readonly classRepository: Repository<CharacterClassEntity>,
+    private readonly _classRepository: Repository<CharacterClassEntity>,
     @InjectRepository(RecruitTypeEntity)
-    private readonly recruitTypeRepository: Repository<RecruitTypeEntity>,
+    private readonly _recruitTypeRepository: Repository<RecruitTypeEntity>,
     @InjectRepository(SpeciesEntity)
-    private readonly speciesRepository: Repository<SpeciesEntity>,
-    private readonly imageUploadsService: ImageUploadsService,
+    private readonly _speciesRepository: Repository<SpeciesEntity>,
+    private readonly _imageUploadsService: ImageUploadsService,
   ) {}
 
   /**
@@ -174,7 +174,7 @@ export class CharacterService {
       where.id = Not(excludeCharacterId);
     }
 
-    const existing = await this.characterRepository.findOne({ where });
+    const existing = await this._characterRepository.findOne({ where });
     if (existing) {
       throw new ConflictException(
         'Character handle already exists for this account',
@@ -193,7 +193,7 @@ export class CharacterService {
     accountId: string,
     userId: string,
   ): Promise<AccountEntity> {
-    const account = await this.accountRepository.findOne({
+    const account = await this._accountRepository.findOne({
       where: { id: accountId },
     });
 
@@ -242,7 +242,7 @@ export class CharacterService {
     const fullHandleNormalized = this.normalizeHandle(fullHandle);
     const fullHandleSlug = this.generateSlug(fullHandle);
 
-    const newCharacter = this.characterRepository.create({
+    const newCharacter = this._characterRepository.create({
       ...createCharacterDto,
       fullHandle,
       fullHandleNormalized,
@@ -250,7 +250,7 @@ export class CharacterService {
     });
 
     try {
-      await this.characterRepository.save(newCharacter);
+      await this._characterRepository.save(newCharacter);
       return newCharacter;
     } catch (error: unknown) {
       throw new InternalServerErrorException('Failed to save a new character', {
@@ -280,7 +280,7 @@ export class CharacterService {
 
     await this.requireOwnedAccount(accountId, userId);
 
-    const characters = await this.characterRepository.find({
+    const characters = await this._characterRepository.find({
       where: { accountId },
       relations: {
         generalFaction: true,
@@ -309,7 +309,7 @@ export class CharacterService {
       throw new BadRequestException('Handle slug is required');
     }
 
-    const character = await this.characterRepository.findOne({
+    const character = await this._characterRepository.findOne({
       where: { fullHandleSlug: handleSlug },
       relations: {
         account: true,
@@ -345,7 +345,7 @@ export class CharacterService {
       throw new BadRequestException('User ID is required');
     }
 
-    const character = await this.characterRepository.findOne({
+    const character = await this._characterRepository.findOne({
       where: { id },
       relations: {
         account: true,
@@ -416,7 +416,7 @@ export class CharacterService {
       updateData.fullHandleSlug = this.generateSlug(fullHandle);
     }
 
-    await this.characterRepository.update(id, updateData);
+    await this._characterRepository.update(id, updateData);
     return this.findOneForUser(id, userId);
   }
 
@@ -436,7 +436,7 @@ export class CharacterService {
     }
 
     const character = await this.findOneForUser(id, userId);
-    await this.characterRepository.softDelete(character.id);
+    await this._characterRepository.softDelete(character.id);
   }
 
   /**
@@ -454,48 +454,48 @@ export class CharacterService {
   ): Promise<CharacterEntity> {
     this.assertUploadProfileImageArgs(id, userId, file);
 
-    this.logger.debug(
+    this._logger.debug(
       `[uploadProfileImage] Starting upload - CharacterId: ${id}, UserId: ${userId}`,
     );
 
     try {
       const character = await this.findOneForUser(id, userId);
-      this.logger.debug(
+      this._logger.debug(
         `[uploadProfileImage] Character found - Handle: ${character.fullHandle}, ExistingProfilePictureId: ${character.profilePictureId || 'none'}`,
       );
 
       const existingProfilePictureId = character.profilePictureId;
 
-      this.logger.debug(
+      this._logger.debug(
         `[uploadProfileImage] Starting Cloudflare Images upload - CharacterId: ${id}, UserId: ${userId}`,
       );
 
       character.profilePictureId =
-        await this.imageUploadsService.uploadImageToCloudflareImages(
+        await this._imageUploadsService.uploadImageToCloudflareImages(
           userId,
           file,
           'character',
           id,
         );
 
-      this.logger.debug(
+      this._logger.debug(
         `[uploadProfileImage] Cloudflare Images upload complete - NewProfilePictureId: ${character.profilePictureId}`,
       );
 
       if (!character.profilePictureId) {
-        this.logger.error(
+        this._logger.error(
           `[uploadProfileImage] Upload returned null/undefined - CharacterId: ${id}`,
         );
         throw new InternalServerErrorException('Profile picture upload failed');
       }
 
-      this.logger.debug(
+      this._logger.debug(
         `[uploadProfileImage] Saving character to database - CharacterId: ${id}`,
       );
 
-      const updatedCharacter = await this.characterRepository.save(character);
+      const updatedCharacter = await this._characterRepository.save(character);
 
-      this.logger.log(
+      this._logger.log(
         `[uploadProfileImage] Character saved successfully - CharacterId: ${id}, ProfilePictureId: ${updatedCharacter.profilePictureId}`,
       );
 
@@ -506,7 +506,7 @@ export class CharacterService {
       const message = stringifyError(error);
 
       const stack = error instanceof Error ? error.stack : undefined;
-      this.logger.error(
+      this._logger.error(
         `[uploadProfileImage] Upload failed - CharacterId: ${id}, UserId: ${userId}, Error: ${message}`,
         stack,
       );
@@ -551,21 +551,21 @@ export class CharacterService {
       return;
     }
 
-    this.logger.debug(
+    this._logger.debug(
       `[uploadProfileImage] Deleting old image - ProfilePictureId: ${existingProfilePictureId}`,
     );
     try {
-      await this.imageUploadsService.deleteImageFromCloudflareImages(
+      await this._imageUploadsService.deleteImageFromCloudflareImages(
         existingProfilePictureId,
       );
-      this.logger.debug(
+      this._logger.debug(
         `[uploadProfileImage] Old image deleted - ProfilePictureId: ${existingProfilePictureId}`,
       );
     } catch (error: unknown) {
       const message = stringifyError(error);
 
       const stack = error instanceof Error ? error.stack : undefined;
-      this.logger.error(
+      this._logger.error(
         `[uploadProfileImage] Failed to delete old profile image from Cloudflare Images - ProfilePictureId: ${existingProfilePictureId}, Error: ${message}`,
         stack,
       );
@@ -584,7 +584,7 @@ export class CharacterService {
     factionId?: string,
   ): Promise<GeneralFactionEntity[]> {
     const query =
-      this.generalFactionRepository.createQueryBuilder('generalFaction');
+      this._generalFactionRepository.createQueryBuilder('generalFaction');
 
     if (factionId) {
       query.innerJoin(
@@ -609,7 +609,7 @@ export class CharacterService {
    * @returns A promise that resolves when the operation completes.
    */
   async getFactions(generalFactionId?: string): Promise<FactionEntity[]> {
-    const query = this.factionRepository.createQueryBuilder('faction');
+    const query = this._factionRepository.createQueryBuilder('faction');
 
     if (generalFactionId) {
       query.innerJoin(
@@ -631,7 +631,7 @@ export class CharacterService {
    * @returns A promise that resolves when the operation completes.
    */
   async getSexes(): Promise<SexEntity[]> {
-    return this.sexRepository.find({ order: { name: 'ASC' } });
+    return this._sexRepository.find({ order: { name: 'ASC' } });
   }
 
   /**
@@ -640,7 +640,7 @@ export class CharacterService {
    * @returns A promise that resolves when the operation completes.
    */
   async getClasses(): Promise<CharacterClassEntity[]> {
-    return this.classRepository.find({ order: { name: 'ASC' } });
+    return this._classRepository.find({ order: { name: 'ASC' } });
   }
 
   /**
@@ -650,7 +650,7 @@ export class CharacterService {
    * @returns A promise that resolves when the operation completes.
    */
   async getRecruitTypes(factionId?: string): Promise<RecruitTypeEntity[]> {
-    const query = this.recruitTypeRepository.createQueryBuilder('recruitType');
+    const query = this._recruitTypeRepository.createQueryBuilder('recruitType');
 
     if (factionId) {
       query.innerJoin(
@@ -675,7 +675,7 @@ export class CharacterService {
     factionId?: string,
     recruitTypeId?: string,
   ): Promise<SpeciesEntity[]> {
-    const query = this.speciesRepository.createQueryBuilder('species');
+    const query = this._speciesRepository.createQueryBuilder('species');
 
     if (factionId) {
       query.innerJoin(

--- a/src/sto/endeavour/endeavour.controller.ts
+++ b/src/sto/endeavour/endeavour.controller.ts
@@ -29,9 +29,9 @@ export class EndeavourController {
   /**
    * Creates an instance of EndeavourController.
    *
-   * @param endeavourService - The endeavour service.
+   * @param _endeavourService - The endeavour service.
    */
-  constructor(private readonly endeavourService: EndeavourService) {}
+  constructor(private readonly _endeavourService: EndeavourService) {}
 
   @Get('perks')
   @ApiOkResponse({ description: 'Successfully retrieved endeavour perks.' })
@@ -43,7 +43,7 @@ export class EndeavourController {
    * @returns The result of the operation.
    */
   getPerks(@Query('category') category?: 'Space' | 'Ground') {
-    return this.endeavourService.getPerks(category);
+    return this._endeavourService.getPerks(category);
   }
 
   @Get('account/:accountId')
@@ -63,7 +63,7 @@ export class EndeavourController {
     @Param('accountId') accountId: string,
     @Query() query: EndeavourProgressQueryDto,
   ) {
-    return this.endeavourService.getProgress(accountId, userId, query);
+    return this._endeavourService.getProgress(accountId, userId, query);
   }
 
   @Get('account/:accountId/summary')
@@ -78,7 +78,7 @@ export class EndeavourController {
    * @returns The result of the operation.
    */
   getSummary(@UserId() userId: string, @Param('accountId') accountId: string) {
-    return this.endeavourService.getSummary(accountId, userId);
+    return this._endeavourService.getSummary(accountId, userId);
   }
 
   @Put('account/:accountId/perk/:perkId')
@@ -100,6 +100,11 @@ export class EndeavourController {
     @Param('perkId') perkId: string,
     @Body() dto: UpdateEndeavourProgressDto,
   ) {
-    return this.endeavourService.updateProgress(accountId, userId, perkId, dto);
+    return this._endeavourService.updateProgress(
+      accountId,
+      userId,
+      perkId,
+      dto,
+    );
   }
 }

--- a/src/sto/endeavour/endeavour.service.ts
+++ b/src/sto/endeavour/endeavour.service.ts
@@ -30,17 +30,17 @@ export class EndeavourService {
   /**
    * Creates an instance of EndeavourService.
    *
-   * @param perkRepository - The perk repository.
-   * @param progressRepository - The progress repository.
-   * @param accountRepository - The account repository.
+   * @param _perkRepository - The perk repository.
+   * @param _progressRepository - The progress repository.
+   * @param _accountRepository - The account repository.
    */
   constructor(
     @InjectRepository(EndeavourPerkEntity)
-    private readonly perkRepository: Repository<EndeavourPerkEntity>,
+    private readonly _perkRepository: Repository<EndeavourPerkEntity>,
     @InjectRepository(AccountEndeavourProgressEntity)
-    private readonly progressRepository: Repository<AccountEndeavourProgressEntity>,
+    private readonly _progressRepository: Repository<AccountEndeavourProgressEntity>,
     @InjectRepository(AccountEntity)
-    private readonly accountRepository: Repository<AccountEntity>,
+    private readonly _accountRepository: Repository<AccountEntity>,
   ) {}
 
   /**
@@ -54,7 +54,7 @@ export class EndeavourService {
     accountId: string,
     userId: string,
   ): Promise<AccountEntity> {
-    const account = await this.accountRepository.findOne({
+    const account = await this._accountRepository.findOne({
       where: { id: accountId },
     });
 
@@ -79,7 +79,7 @@ export class EndeavourService {
     category?: 'Space' | 'Ground',
   ): Promise<EndeavourPerkEntity[]> {
     const where = category ? { category } : {};
-    return this.perkRepository.find({
+    return this._perkRepository.find({
       where,
       order: { sortOrder: 'ASC', name: 'ASC' },
     });
@@ -102,7 +102,7 @@ export class EndeavourService {
 
     const allPerks = await this.getPerks(query.category);
 
-    const existingProgress = await this.progressRepository.find({
+    const existingProgress = await this._progressRepository.find({
       where: { accountId },
       relations: { endeavourPerk: true },
     });
@@ -162,20 +162,20 @@ export class EndeavourService {
   ): Promise<AccountEndeavourProgressEntity> {
     await this.requireOwnedAccount(accountId, userId);
 
-    const perk = await this.perkRepository.findOne({ where: { id: perkId } });
+    const perk = await this._perkRepository.findOne({ where: { id: perkId } });
     if (!perk) {
       throw new NotFoundException(
         `Endeavour perk with ID "${perkId}" not found`,
       );
     }
 
-    let progress = await this.progressRepository.findOne({
+    let progress = await this._progressRepository.findOne({
       where: { accountId, endeavourPerkId: perkId },
       relations: { endeavourPerk: true },
     });
 
     if (!progress) {
-      progress = this.progressRepository.create({
+      progress = this._progressRepository.create({
         accountId,
         endeavourPerkId: perkId,
         currentNodes: dto.currentNodes,
@@ -184,7 +184,7 @@ export class EndeavourService {
       progress.currentNodes = dto.currentNodes;
     }
 
-    await this.progressRepository.save(progress);
+    await this._progressRepository.save(progress);
 
     progress.endeavourPerk = perk;
     return progress;
@@ -203,8 +203,8 @@ export class EndeavourService {
   ): Promise<EndeavourSummary> {
     await this.requireOwnedAccount(accountId, userId);
 
-    const allPerks = await this.perkRepository.find();
-    const existingProgress = await this.progressRepository.find({
+    const allPerks = await this._perkRepository.find();
+    const existingProgress = await this._progressRepository.find({
       where: { accountId },
     });
 

--- a/src/sto/launcher/launcher.controller.ts
+++ b/src/sto/launcher/launcher.controller.ts
@@ -8,9 +8,9 @@ export class LauncherController {
   /**
    * Creates an instance of LauncherController.
    *
-   * @param launcherService - The launcher service.
+   * @param _launcherService - The launcher service.
    */
-  constructor(private readonly launcherService: LauncherService) {}
+  constructor(private readonly _launcherService: LauncherService) {}
 
   @Get()
   /**
@@ -19,6 +19,6 @@ export class LauncherController {
    * @returns The result of the operation.
    */
   findAll() {
-    return this.launcherService.findAll();
+    return this._launcherService.findAll();
   }
 }

--- a/src/sto/launcher/launcher.service.ts
+++ b/src/sto/launcher/launcher.service.ts
@@ -16,11 +16,11 @@ export class LauncherService {
   /**
    * Creates an instance of LauncherService.
    *
-   * @param launcherRepository - The launcher repository.
+   * @param _launcherRepository - The launcher repository.
    */
   constructor(
     @InjectRepository(LauncherEntity)
-    private readonly launcherRepository: Repository<LauncherEntity>,
+    private readonly _launcherRepository: Repository<LauncherEntity>,
   ) {}
 
   /**
@@ -29,7 +29,7 @@ export class LauncherService {
    * @returns A promise that resolves when the operation completes.
    */
   async findAll() {
-    return await this.launcherRepository.find();
+    return await this._launcherRepository.find();
   }
 
   /**
@@ -43,7 +43,7 @@ export class LauncherService {
       throw new BadRequestException('Launcher ID is required');
     }
 
-    const launcher = await this.launcherRepository.findOne({
+    const launcher = await this._launcherRepository.findOne({
       where: {
         id: id,
       },
@@ -67,7 +67,7 @@ export class LauncherService {
       throw new BadRequestException('Launcher name is required');
     }
 
-    const launcher = await this.launcherRepository.findOne({
+    const launcher = await this._launcherRepository.findOne({
       where: { name: name },
     });
 
@@ -87,7 +87,7 @@ export class LauncherService {
     const oneWeekAgo = new Date();
     oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
 
-    return this.launcherRepository
+    return this._launcherRepository
       .createQueryBuilder('launcher')
       .where('launcher.deletedAt IS NOT NULL')
       .andWhere('launcher.deletedAt < :oneWeekAgo', { oneWeekAgo })
@@ -105,9 +105,9 @@ export class LauncherService {
       throw new BadRequestException('Launcher data is required');
     }
 
-    const newLauncher = this.launcherRepository.create(createLauncherDto);
+    const newLauncher = this._launcherRepository.create(createLauncherDto);
     try {
-      await this.launcherRepository.save(newLauncher);
+      await this._launcherRepository.save(newLauncher);
       return newLauncher;
     } catch (error: unknown) {
       throw new InternalServerErrorException('Failed to save a new launcher', {
@@ -136,12 +136,12 @@ export class LauncherService {
     }
 
     const launcher = await this.findOne(id);
-    const updatedLauncher = this.launcherRepository.merge(
+    const updatedLauncher = this._launcherRepository.merge(
       launcher,
       updateLauncherDto,
     );
     try {
-      await this.launcherRepository.save(updatedLauncher);
+      await this._launcherRepository.save(updatedLauncher);
       return updatedLauncher;
     } catch (error: unknown) {
       throw new InternalServerErrorException('Failed to update launcher', {
@@ -162,7 +162,7 @@ export class LauncherService {
 
     const launcher = await this.findOne(id);
     try {
-      await this.launcherRepository.remove(launcher);
+      await this._launcherRepository.remove(launcher);
     } catch (error: unknown) {
       throw new InternalServerErrorException('Failed to delete launcher', {
         cause: error,
@@ -182,7 +182,7 @@ export class LauncherService {
 
     const launcher = await this.findOne(id);
     try {
-      await this.launcherRepository.softDelete(launcher.id);
+      await this._launcherRepository.softDelete(launcher.id);
     } catch (error: unknown) {
       throw new InternalServerErrorException('Failed to soft delete launcher', {
         cause: error,

--- a/src/sto/platform-launcher/platform-launcher.controller.ts
+++ b/src/sto/platform-launcher/platform-launcher.controller.ts
@@ -8,10 +8,10 @@ export class PlatformLauncherController {
   /**
    * Creates an instance of PlatformLauncherController.
    *
-   * @param platformLauncherService - The platform launcher service.
+   * @param _platformLauncherService - The platform launcher service.
    */
   constructor(
-    private readonly platformLauncherService: PlatformLauncherService,
+    private readonly _platformLauncherService: PlatformLauncherService,
   ) {}
 
   @Get()
@@ -21,6 +21,6 @@ export class PlatformLauncherController {
    * @returns The result of the operation.
    */
   findAll() {
-    return this.platformLauncherService.findAll();
+    return this._platformLauncherService.findAll();
   }
 }

--- a/src/sto/platform-launcher/platform-launcher.service.ts
+++ b/src/sto/platform-launcher/platform-launcher.service.ts
@@ -14,11 +14,11 @@ export class PlatformLauncherService {
   /**
    * Creates an instance of PlatformLauncherService.
    *
-   * @param platformLauncherRepository - The platform launcher repository.
+   * @param _platformLauncherRepository - The platform launcher repository.
    */
   constructor(
     @InjectRepository(PlatformLauncherEntity)
-    private readonly platformLauncherRepository: Repository<PlatformLauncherEntity>,
+    private readonly _platformLauncherRepository: Repository<PlatformLauncherEntity>,
   ) {}
 
   /**
@@ -57,7 +57,7 @@ export class PlatformLauncherService {
     platformLauncher.platformId = platformId;
     platformLauncher.launcherId = launcherId;
     try {
-      await this.platformLauncherRepository.save(platformLauncher);
+      await this._platformLauncherRepository.save(platformLauncher);
       return platformLauncher;
     } catch (error: unknown) {
       throw new InternalServerErrorException(
@@ -83,14 +83,14 @@ export class PlatformLauncherService {
       throw new BadRequestException('Launcher ID is required');
     }
 
-    const platformLauncher = await this.platformLauncherRepository.findOne({
+    const platformLauncher = await this._platformLauncherRepository.findOne({
       where: { platformId: platformId, launcherId: launcherId },
     });
     if (!platformLauncher) {
       throw new NotFoundException(`PlatformLauncherEntity relation not found`);
     }
     try {
-      await this.platformLauncherRepository.remove(platformLauncher);
+      await this._platformLauncherRepository.remove(platformLauncher);
     } catch (error: unknown) {
       throw new InternalServerErrorException(
         'Failed to remove platform-launcher relation',
@@ -105,7 +105,7 @@ export class PlatformLauncherService {
    * @returns A promise that resolves when the operation completes.
    */
   async findAll(): Promise<PlatformLauncherEntity[]> {
-    const relations = await this.platformLauncherRepository.find({
+    const relations = await this._platformLauncherRepository.find({
       relations: { platform: true, launcher: true },
     });
 
@@ -125,7 +125,7 @@ export class PlatformLauncherService {
       throw new BadRequestException('Platform ID is required');
     }
 
-    const launchers = await this.platformLauncherRepository.find({
+    const launchers = await this._platformLauncherRepository.find({
       where: { platformId: platformId },
     });
     return launchers.map(relation => this.sanitizeBackgroundImageUrl(relation));
@@ -150,7 +150,7 @@ export class PlatformLauncherService {
       throw new BadRequestException('Launcher ID is required');
     }
 
-    const platformLauncher = await this.platformLauncherRepository.findOne({
+    const platformLauncher = await this._platformLauncherRepository.findOne({
       where: { platformId: platformId, launcherId: launcherId },
     });
 

--- a/src/sto/platform/platform.controller.ts
+++ b/src/sto/platform/platform.controller.ts
@@ -8,9 +8,9 @@ export class PlatformController {
   /**
    * Creates an instance of PlatformController.
    *
-   * @param platformService - The platform service.
+   * @param _platformService - The platform service.
    */
-  constructor(private readonly platformService: PlatformService) {}
+  constructor(private readonly _platformService: PlatformService) {}
 
   @Get()
   /**
@@ -19,6 +19,6 @@ export class PlatformController {
    * @returns The result of the operation.
    */
   findAll() {
-    return this.platformService.findAll();
+    return this._platformService.findAll();
   }
 }

--- a/src/sto/platform/platform.service.ts
+++ b/src/sto/platform/platform.service.ts
@@ -16,11 +16,11 @@ export class PlatformService {
   /**
    * Creates an instance of PlatformService.
    *
-   * @param platformRepository - The platform repository.
+   * @param _platformRepository - The platform repository.
    */
   constructor(
     @InjectRepository(PlatformEntity)
-    private readonly platformRepository: Repository<PlatformEntity>,
+    private readonly _platformRepository: Repository<PlatformEntity>,
   ) {}
 
   /**
@@ -29,7 +29,7 @@ export class PlatformService {
    * @returns A promise that resolves when the operation completes.
    */
   async findAll() {
-    return await this.platformRepository.find();
+    return await this._platformRepository.find();
   }
 
   /**
@@ -43,7 +43,7 @@ export class PlatformService {
       throw new BadRequestException('Platform ID is required');
     }
 
-    const platform = await this.platformRepository.findOne({
+    const platform = await this._platformRepository.findOne({
       where: {
         id: id,
       },
@@ -67,7 +67,7 @@ export class PlatformService {
       throw new BadRequestException('Platform name is required');
     }
 
-    const platform = await this.platformRepository.findOne({
+    const platform = await this._platformRepository.findOne({
       where: { name: name },
     });
 
@@ -87,7 +87,7 @@ export class PlatformService {
     const oneWeekAgo = new Date();
     oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
 
-    return this.platformRepository
+    return this._platformRepository
       .createQueryBuilder('platform')
       .where('platform.deletedAt IS NOT NULL')
       .andWhere('platform.deletedAt < :oneWeekAgo', { oneWeekAgo })
@@ -105,9 +105,9 @@ export class PlatformService {
       throw new BadRequestException('Platform data is required');
     }
 
-    const newPlatform = this.platformRepository.create(createPlatformDto);
+    const newPlatform = this._platformRepository.create(createPlatformDto);
     try {
-      await this.platformRepository.save(newPlatform);
+      await this._platformRepository.save(newPlatform);
       return newPlatform;
     } catch (error: unknown) {
       throw new InternalServerErrorException('Failed to save a new platform', {
@@ -136,12 +136,12 @@ export class PlatformService {
     }
 
     const platform = await this.findOne(id);
-    const updatedPlatform = this.platformRepository.merge(
+    const updatedPlatform = this._platformRepository.merge(
       platform,
       updatePlatformDto,
     );
     try {
-      await this.platformRepository.save(updatedPlatform);
+      await this._platformRepository.save(updatedPlatform);
       return updatedPlatform;
     } catch (error: unknown) {
       throw new InternalServerErrorException('Failed to update platform', {
@@ -162,7 +162,7 @@ export class PlatformService {
 
     const platform = await this.findOne(id);
     try {
-      await this.platformRepository.remove(platform);
+      await this._platformRepository.remove(platform);
     } catch (error: unknown) {
       throw new InternalServerErrorException('Failed to delete platform', {
         cause: error,
@@ -182,7 +182,7 @@ export class PlatformService {
 
     const platform = await this.findOne(id);
     try {
-      await this.platformRepository.softDelete(platform.id);
+      await this._platformRepository.softDelete(platform.id);
     } catch (error: unknown) {
       throw new InternalServerErrorException('Failed to soft delete platform', {
         cause: error,

--- a/src/sto/stats/stats.controller.ts
+++ b/src/sto/stats/stats.controller.ts
@@ -25,9 +25,9 @@ export class StatsController {
   /**
    * Creates an instance of StatsController.
    *
-   * @param statsService - The stats service.
+   * @param _statsService - The stats service.
    */
-  constructor(private readonly statsService: StatsService) {}
+  constructor(private readonly _statsService: StatsService) {}
 
   /**
    * Returns pre-computed statistics for the authenticated user, aggregating
@@ -54,6 +54,6 @@ export class StatsController {
     @UserId() userId: string,
     @Query('accountId') accountId?: string,
   ): Promise<StatsResponseDto> {
-    return this.statsService.getStats(userId, accountId);
+    return this._statsService.getStats(userId, accountId);
   }
 }

--- a/src/sto/stats/stats.service.ts
+++ b/src/sto/stats/stats.service.ts
@@ -28,21 +28,21 @@ export class StatsService {
   /**
    * Creates an instance of StatsService.
    *
-   * @param accountRepository - The account repository.
-   * @param characterRepository - The character repository.
-   * @param characterRankRepository - The character rank repository.
+   * @param _accountRepository - The account repository.
+   * @param _characterRepository - The character repository.
+   * @param _characterRankRepository - The character rank repository.
    */
   constructor(
     @InjectRepository(AccountEntity)
-    private readonly accountRepository: Repository<AccountEntity>,
+    private readonly _accountRepository: Repository<AccountEntity>,
     @InjectRepository(CharacterEntity)
-    private readonly characterRepository: Repository<CharacterEntity>,
+    private readonly _characterRepository: Repository<CharacterEntity>,
     @InjectRepository(CharacterRankEntity)
-    private readonly characterRankRepository: Repository<CharacterRankEntity>,
+    private readonly _characterRankRepository: Repository<CharacterRankEntity>,
     @InjectRepository(AccountEndeavourProgressEntity)
-    private readonly progressRepository: Repository<AccountEndeavourProgressEntity>,
+    private readonly _progressRepository: Repository<AccountEndeavourProgressEntity>,
     @InjectRepository(EndeavourPerkEntity)
-    private readonly endeavourPerkRepository: Repository<EndeavourPerkEntity>,
+    private readonly _endeavourPerkRepository: Repository<EndeavourPerkEntity>,
   ) {}
 
   /**
@@ -69,7 +69,7 @@ export class StatsService {
     let lifetimeSubCount: number;
 
     if (accountId) {
-      const account = await this.accountRepository.findOne({
+      const account = await this._accountRepository.findOne({
         where: { id: accountId, user: { id: userId } },
         select: { id: true, lifetimeSubscription: true },
       });
@@ -80,14 +80,14 @@ export class StatsService {
       lifetimeSubCount = account.lifetimeSubscription ? 1 : 0;
     } else {
       [accountCount, lifetimeSubCount] = await Promise.all([
-        this.accountRepository.count({ where: { user: { id: userId } } }),
-        this.accountRepository.count({
+        this._accountRepository.count({ where: { user: { id: userId } } }),
+        this._accountRepository.count({
           where: { user: { id: userId }, lifetimeSubscription: true },
         }),
       ]);
     }
 
-    const mgr = this.accountRepository.manager;
+    const mgr = this._accountRepository.manager;
 
     const [
       levelStats,
@@ -156,7 +156,7 @@ export class StatsService {
     userId: string,
     accountId?: string,
   ): SelectQueryBuilder<CharacterEntity> {
-    const qb = this.characterRepository
+    const qb = this._characterRepository
       .createQueryBuilder('c')
       .innerJoin('c.account', 'a')
       .where('a.userId = :userId', { userId });
@@ -271,7 +271,7 @@ export class StatsService {
     byRecruitType: CountItemDto[];
   }> {
     const base = this.characterBaseQb(userId, accountId);
-    const mgr = this.characterRepository.manager;
+    const mgr = this._characterRepository.manager;
 
     const [
       bySpeciesRaw,
@@ -351,7 +351,7 @@ export class StatsService {
     allNames: string[],
     accountId?: string,
   ): Promise<CountItemDto[]> {
-    const qb = this.accountRepository
+    const qb = this._accountRepository
       .createQueryBuilder('a')
       .leftJoin(`a.${relation}`, alias)
       .where('a.userId = :userId', { userId })
@@ -397,7 +397,7 @@ export class StatsService {
       .groupBy('c.level');
 
     const [tiers, levelCounts] = await Promise.all([
-      this.characterRankRepository
+      this._characterRankRepository
         .createQueryBuilder('cr')
         .innerJoin('cr.faction', 'f')
         .where('f.name = :name', { name: LEVEL_RANGE_FACTION })
@@ -452,12 +452,12 @@ export class StatsService {
     byEndeavourCategory: CountItemDto[];
     byEndeavourCategoryPct: CountItemDto[];
   }> {
-    const allPerks = await this.endeavourPerkRepository.find({
+    const allPerks = await this._endeavourPerkRepository.find({
       select: { name: true, category: true, maxNodes: true, sortOrder: true },
       order: { sortOrder: 'ASC' },
     });
 
-    const qb = this.progressRepository
+    const qb = this._progressRepository
       .createQueryBuilder('aep')
       .innerJoin('aep.account', 'a')
       .where('a.userId = :userId', { userId });

--- a/src/user-refresh-token/user-refresh-token.service.ts
+++ b/src/user-refresh-token/user-refresh-token.service.ts
@@ -20,15 +20,15 @@ export class UserRefreshTokenService {
   /**
    * Creates an instance of UserRefreshTokenService.
    *
-   * @param refreshTokenRepository - The refresh token repository.
-   * @param configService - The config service.
-   * @param secretsService - The secrets service.
+   * @param _refreshTokenRepository - The refresh token repository.
+   * @param _configService - The config service.
+   * @param _secretsService - The secrets service.
    */
   constructor(
     @InjectRepository(UserRefreshTokenEntity)
-    private readonly refreshTokenRepository: Repository<UserRefreshTokenEntity>,
-    private readonly configService: ConfigService,
-    private readonly secretsService: SecretsService,
+    private readonly _refreshTokenRepository: Repository<UserRefreshTokenEntity>,
+    private readonly _configService: ConfigService,
+    private readonly _secretsService: SecretsService,
   ) {}
 
   /**
@@ -41,12 +41,12 @@ export class UserRefreshTokenService {
   private async verifyAndDecodeRefreshToken(
     rawRefreshToken: string,
   ): Promise<jwt.JwtPayload> {
-    const secretName = this.configService.get<string>('AWS_SECRET_NAME');
+    const secretName = this._configService.get<string>('AWS_SECRET_NAME');
     if (!secretName) {
       throw new UnauthorizedException('Refresh token verification unavailable');
     }
 
-    const secretObject = await this.secretsService.getSecret(secretName);
+    const secretObject = await this._secretsService.getSecret(secretName);
     if (!secretObject?.jwtSecret) {
       throw new UnauthorizedException('Refresh token verification unavailable');
     }
@@ -77,7 +77,7 @@ export class UserRefreshTokenService {
       throw new BadRequestException('Refresh token data is required');
     }
 
-    const refreshToken = this.refreshTokenRepository.create(refreshTokenDto);
+    const refreshToken = this._refreshTokenRepository.create(refreshTokenDto);
 
     // If we have a raw token string in tokenId, we hash it for storage
     // However, we should prefer using jwtId (JTI) for identification
@@ -97,7 +97,7 @@ export class UserRefreshTokenService {
 
     refreshToken.expiresAt = expiresAt;
 
-    return this.refreshTokenRepository.save(refreshToken);
+    return this._refreshTokenRepository.save(refreshToken);
   }
 
   /**
@@ -112,7 +112,7 @@ export class UserRefreshTokenService {
       throw new BadRequestException('Token ID is required');
     }
 
-    return await this.refreshTokenRepository.findOne({
+    return await this._refreshTokenRepository.findOne({
       where: { tokenId: tokenId },
     });
   }
@@ -173,7 +173,7 @@ export class UserRefreshTokenService {
       +process.env.AUTH_SALT_ROUNDS!,
     );
 
-    return await this.refreshTokenRepository.save(refreshTokenEntity);
+    return await this._refreshTokenRepository.save(refreshTokenEntity);
   }
 
   /**
@@ -199,7 +199,7 @@ export class UserRefreshTokenService {
       return;
     }
 
-    await this.refreshTokenRepository.update(
+    await this._refreshTokenRepository.update(
       { jwtId: payload.jti, isRevoked: false },
       { isRevoked: true },
     );
@@ -233,7 +233,7 @@ export class UserRefreshTokenService {
       throw new UnauthorizedException('Invalid refresh token');
     }
 
-    const tokenRecord = await this.refreshTokenRepository.findOne({
+    const tokenRecord = await this._refreshTokenRepository.findOne({
       where: { jwtId: payload.jti, userId: userId },
     });
 
@@ -243,7 +243,7 @@ export class UserRefreshTokenService {
 
     // Mark as revoked
     tokenRecord.isRevoked = true;
-    await this.refreshTokenRepository.save(tokenRecord);
+    await this._refreshTokenRepository.save(tokenRecord);
   }
 
   /**
@@ -260,7 +260,7 @@ export class UserRefreshTokenService {
       throw new BadRequestException('User ID is required');
     }
 
-    await this.refreshTokenRepository.update(
+    await this._refreshTokenRepository.update(
       { user: { id: userId }, isRevoked: false },
       { isRevoked: true },
     );
@@ -275,7 +275,7 @@ export class UserRefreshTokenService {
   async cleanupExpiredAndRevokedTokens(): Promise<void> {
     const now = new Date();
 
-    await this.refreshTokenRepository
+    await this._refreshTokenRepository
       .createQueryBuilder()
       .delete()
       .where('expiresAt < :now OR isRevoked = :revoked', { now, revoked: true })

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -52,9 +52,9 @@ export class UserController {
   /**
    * Creates an instance of UserController.
    *
-   * @param userService - The user service.
+   * @param _userService - The user service.
    */
-  constructor(private readonly userService: UserService) {}
+  constructor(private readonly _userService: UserService) {}
 
   /**
    * Filter for image file uploads.
@@ -103,7 +103,7 @@ export class UserController {
   @Get()
   @HttpCode(HttpStatus.OK)
   async findUser(@UserId() userId: string): Promise<UserEntity> {
-    return await this.userService.findById(userId);
+    return await this._userService.findById(userId);
   }
 
   /**
@@ -128,7 +128,7 @@ export class UserController {
   @Delete('close-account')
   @HttpCode(HttpStatus.OK)
   async closeAccount(@UserId() userId: string): Promise<{ success: true }> {
-    await this.userService.closeAccount(userId);
+    await this._userService.closeAccount(userId);
     return { success: true };
   }
 
@@ -168,7 +168,7 @@ export class UserController {
     if (!userProfileData) {
       throw new HttpException('User data is required', HttpStatus.BAD_REQUEST);
     }
-    const result = await this.userService.updateUserProfile(
+    const result = await this._userService.updateUserProfile(
       userId,
       userProfileData,
     );
@@ -250,7 +250,7 @@ export class UserController {
     const uniqueSuffix = Date.now().toString() + '-' + crypto.randomUUID();
     file.filename = `${file.fieldname}-${uniqueSuffix}${extname(file.originalname)}`;
 
-    const result = await this.userService.uploadProfilePicture(userId, file);
+    const result = await this._userService.uploadProfilePicture(userId, file);
 
     return new UpdatedUserProfileResultDto(
       result.affected,

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -17,26 +17,26 @@ import { UserEntity } from './entities/user.entity';
 
 @Injectable()
 export class UserService {
-  private readonly logger = new Logger(UserService.name);
+  private readonly _logger = new Logger(UserService.name);
 
   /**
    * Creates an instance of UserService.
    *
-   * @param userRepository - The user repository.
-   * @param userProfileRepository - The user profile repository.
-   * @param validatorsService - The validators service.
-   * @param imageUploadsService - The image uploads service.
+   * @param _userRepository - The user repository.
+   * @param _userProfileRepository - The user profile repository.
+   * @param _validatorsService - The validators service.
+   * @param _imageUploadsService - The image uploads service.
    */
   constructor(
     @InjectRepository(UserEntity)
-    private readonly userRepository: Repository<UserEntity>,
+    private readonly _userRepository: Repository<UserEntity>,
 
     @InjectRepository(UserProfileEntity)
-    private readonly userProfileRepository: Repository<UserProfileEntity>,
+    private readonly _userProfileRepository: Repository<UserProfileEntity>,
 
-    private readonly validatorsService: ValidatorsService,
-    private readonly imageUploadsService: ImageUploadsService,
-    private readonly mailService: MailService,
+    private readonly _validatorsService: ValidatorsService,
+    private readonly _imageUploadsService: ImageUploadsService,
+    private readonly _mailService: MailService,
   ) {}
 
   /**
@@ -47,30 +47,30 @@ export class UserService {
    * @throws HttpException if the email is invalid, the password is missing, or the email is already in use.
    */
   async create(createUserDto: CreateUserDto): Promise<UserEntity> {
-    this.logger.debug(
+    this._logger.debug(
       `[create] Creating new user - Email: ${createUserDto.email}`,
     );
 
     if (!this.validateEmailUsername(createUserDto.email)) {
-      this.logger.warn(
+      this._logger.warn(
         `[create] Invalid email format - Email: ${createUserDto.email}`,
       );
       throw new HttpException('Invalid email', HttpStatus.BAD_REQUEST);
     }
 
     if (!createUserDto.password) {
-      this.logger.warn(
+      this._logger.warn(
         `[create] Missing password - Email: ${createUserDto.email}`,
       );
       throw new HttpException('Invalid password', HttpStatus.BAD_REQUEST);
     }
 
     if (
-      await this.userRepository.findOne({
+      await this._userRepository.findOne({
         where: { email: createUserDto.email },
       })
     ) {
-      this.logger.warn(
+      this._logger.warn(
         `[create] Email already exists - Email: ${createUserDto.email}`,
       );
       throw new HttpException('Email already in use', HttpStatus.BAD_REQUEST);
@@ -84,9 +84,9 @@ export class UserService {
     );
     user.emailVerified = false;
 
-    const newUser = await this.userRepository.save(user);
+    const newUser = await this._userRepository.save(user);
 
-    this.logger.log(
+    this._logger.log(
       `[create] User created successfully - UserId: ${newUser.id}, Email: ${newUser.email}`,
     );
     return newUser;
@@ -101,15 +101,15 @@ export class UserService {
    * @throws HttpException if the ID is invalid or the user is not found after update.
    */
   async update(id: string, post: UpdateUserDto): Promise<UserEntity> {
-    if (!id || !this.validatorsService.validateUuid(id)) {
+    if (!id || !this._validatorsService.validateUuid(id)) {
       throw new HttpException(
         'Invalid username and password',
         HttpStatus.NOT_FOUND,
       );
     }
 
-    await this.userRepository.update(id, post);
-    const updatedUser = await this.userRepository.findOne({
+    await this._userRepository.update(id, post);
+    const updatedUser = await this._userRepository.findOne({
       where: { id: id },
     });
     if (updatedUser) {
@@ -130,14 +130,14 @@ export class UserService {
    * @throws HttpException if the ID is invalid or no user was affected by the deletion.
    */
   async delete(id: string) {
-    if (!id || !this.validatorsService.validateUuid(id)) {
+    if (!id || !this._validatorsService.validateUuid(id)) {
       throw new HttpException(
         'Invalid username and password',
         HttpStatus.NOT_FOUND,
       );
     }
 
-    const deletedUser = await this.userRepository.softDelete(id);
+    const deletedUser = await this._userRepository.softDelete(id);
     if (!deletedUser.affected) {
       throw new HttpException(
         'Invalid username and password',
@@ -156,11 +156,11 @@ export class UserService {
    * @param userId - The authenticated user's UUID.
    */
   async closeAccount(userId: string): Promise<void> {
-    if (!userId || !this.validatorsService.validateUuid(userId)) {
+    if (!userId || !this._validatorsService.validateUuid(userId)) {
       throw new HttpException('User not found', HttpStatus.NOT_FOUND);
     }
 
-    const user = await this.userRepository.findOne({
+    const user = await this._userRepository.findOne({
       where: { id: userId },
       relations: { profile: true },
     });
@@ -172,7 +172,7 @@ export class UserService {
     const closureEmail = user.email;
     const closureFirstName = user.profile?.firstName || 'Captain!';
 
-    await this.userRepository.manager.transaction(async manager => {
+    await this._userRepository.manager.transaction(async manager => {
       await manager.update(
         UserRefreshTokenEntity,
         { userId, isRevoked: false },
@@ -197,7 +197,7 @@ export class UserService {
       await manager.softDelete(UserEntity, userId);
     });
 
-    await this.mailService.sendAccountClosureEmail(
+    await this._mailService.sendAccountClosureEmail(
       closureEmail,
       closureFirstName,
     );
@@ -211,14 +211,14 @@ export class UserService {
    * @throws HttpException if the ID is invalid or the user is not found.
    */
   async findById(id: string): Promise<UserEntity> {
-    if (!id || !this.validatorsService.validateUuid(id)) {
+    if (!id || !this._validatorsService.validateUuid(id)) {
       throw new HttpException(
         'Invalid username and password',
         HttpStatus.NOT_FOUND,
       );
     }
 
-    const user = await this.userRepository.findOne({
+    const user = await this._userRepository.findOne({
       where: {
         id: id,
       },
@@ -239,7 +239,7 @@ export class UserService {
    * @returns A promise that resolves to the UserEntity or null if not found.
    */
   async findByEmail(email: string): Promise<UserEntity | null> {
-    return await this.userRepository.findOne({
+    return await this._userRepository.findOne({
       where: { email: email },
       relations: { profile: true },
     });
@@ -257,13 +257,15 @@ export class UserService {
     email: string,
     verified: boolean,
   ): Promise<void> {
-    const user = await this.userRepository.findOne({ where: { email: email } });
+    const user = await this._userRepository.findOne({
+      where: { email: email },
+    });
     if (!user) {
       throw new HttpException('User not found', HttpStatus.NOT_FOUND);
     }
 
     user.emailVerified = verified;
-    await this.userRepository.save(user);
+    await this._userRepository.save(user);
   }
 
   /**
@@ -276,7 +278,7 @@ export class UserService {
     if (!email) {
       return false;
     }
-    return this.validatorsService.validateEmail(email);
+    return this._validatorsService.validateEmail(email);
   }
 
   /**
@@ -291,11 +293,11 @@ export class UserService {
     userId: string,
     userProfileData: UpdateUserProfileDto,
   ): Promise<{ affected: number; updatedProfile: UserProfileEntity }> {
-    if (!userId || !this.validatorsService.validateUuid(userId)) {
+    if (!userId || !this._validatorsService.validateUuid(userId)) {
       throw new HttpException('User not found', HttpStatus.NOT_FOUND);
     }
 
-    const user = await this.userRepository.findOne({
+    const user = await this._userRepository.findOne({
       where: { id: userId },
       relations: { profile: true },
     });
@@ -333,7 +335,8 @@ export class UserService {
     userProfileData.profilePictureId = user.profile.profilePictureId;
     userProfileData.publiclyVisible = user.profile.publiclyVisible;
 
-    const updateResult = await this.userProfileRepository.save(userProfileData);
+    const updateResult =
+      await this._userProfileRepository.save(userProfileData);
     if (!updateResult) {
       throw new HttpException(
         'User profile update failed',
@@ -341,7 +344,7 @@ export class UserService {
       );
     }
 
-    const updatedProfile = await this.userProfileRepository.findOne({
+    const updatedProfile = await this._userProfileRepository.findOne({
       where: { userId: userId },
     });
 
@@ -365,7 +368,7 @@ export class UserService {
    * @returns A promise that resolves to a boolean indicating whether the username exists.
    */
   async doesUsernameExist(username: string): Promise<boolean> {
-    const count = await this.userProfileRepository
+    const count = await this._userProfileRepository
       .createQueryBuilder('user_profile')
       .where('LOWER(user_profile.username) = LOWER(:username)', { username })
       .getCount();
@@ -379,7 +382,7 @@ export class UserService {
    * @returns A promise that resolves to a boolean indicating whether the email exists.
    */
   async doesEmailExist(email: string): Promise<boolean> {
-    const count = await this.userRepository
+    const count = await this._userRepository
       .createQueryBuilder('user')
       .where('LOWER(user.email) = LOWER(:email)', { email })
       .getCount();
@@ -400,11 +403,11 @@ export class UserService {
     userId: string,
     file: Express.Multer.File,
   ): Promise<UpdatedUserProfileResultDto> {
-    if (!userId || !this.validatorsService.validateUuid(userId)) {
+    if (!userId || !this._validatorsService.validateUuid(userId)) {
       throw new HttpException('User not found', HttpStatus.NOT_FOUND);
     }
 
-    const user = await this.userRepository.findOne({
+    const user = await this._userRepository.findOne({
       where: { id: userId },
       relations: { profile: true },
     });
@@ -420,7 +423,7 @@ export class UserService {
     const existingProfilePictureId = user.profile.profilePictureId;
 
     user.profile.profilePictureId =
-      await this.imageUploadsService.uploadImageToCloudflareImages(
+      await this._imageUploadsService.uploadImageToCloudflareImages(
         userId,
         file,
         'user',
@@ -434,7 +437,7 @@ export class UserService {
       );
     }
 
-    const updatedUserProfile = await this.userProfileRepository.save(
+    const updatedUserProfile = await this._userProfileRepository.save(
       user.profile,
     );
 
@@ -446,7 +449,7 @@ export class UserService {
     }
 
     if (existingProfilePictureId) {
-      await this.imageUploadsService.deleteImageFromCloudflareImages(
+      await this._imageUploadsService.deleteImageFromCloudflareImages(
         existingProfilePictureId,
       );
     }

--- a/src/webhooks/ses/ses-webhook.controller.ts
+++ b/src/webhooks/ses/ses-webhook.controller.ts
@@ -24,14 +24,14 @@ import { SesWebhookService } from './ses-webhook.service';
  */
 @Controller('webhooks/ses')
 export class SesWebhookController {
-  private readonly logger = new Logger(SesWebhookController.name);
+  private readonly _logger = new Logger(SesWebhookController.name);
 
   /**
    * Creates an instance of SesWebhookController.
    *
-   * @param sesWebhookService - The ses webhook service.
+   * @param _sesWebhookService - The ses webhook service.
    */
-  constructor(private readonly sesWebhookService: SesWebhookService) {}
+  constructor(private readonly _sesWebhookService: SesWebhookService) {}
 
   @Post()
   @HttpCode(HttpStatus.OK)
@@ -54,13 +54,13 @@ export class SesWebhookController {
           ? (JSON.parse(body) as SnsEnvelope)
           : (body as SnsEnvelope);
     } catch {
-      this.logger.error('Failed to parse SNS request body');
+      this._logger.error('Failed to parse SNS request body');
       return;
     }
 
     // Validate the TopicArn to prevent spoofed notifications
-    if (!this.sesWebhookService.validateTopicArn(envelope)) {
-      this.logger.error(
+    if (!this._sesWebhookService.validateTopicArn(envelope)) {
+      this._logger.error(
         `Rejected SNS notification: unexpected TopicArn "${envelope.TopicArn}"`,
       );
       throw new ForbiddenException('Invalid SNS TopicArn');
@@ -71,7 +71,7 @@ export class SesWebhookController {
     if (type === 'SubscriptionConfirmation') {
       const subscribeUrl = envelope.SubscribeURL;
       if (!subscribeUrl) {
-        this.logger.error('SubscriptionConfirmation missing SubscribeURL');
+        this._logger.error('SubscriptionConfirmation missing SubscribeURL');
         return;
       }
 
@@ -93,19 +93,19 @@ export class SesWebhookController {
       }
 
       if (!isValid) {
-        this.logger.error(
+        this._logger.error(
           'Rejected SNS subscription confirmation due to invalid SubscribeURL format or domain',
         );
         return;
       }
 
-      await this.sesWebhookService.confirmSubscription(subscribeUrl);
+      await this._sesWebhookService.confirmSubscription(subscribeUrl);
       return;
     }
 
     if (type === 'Notification') {
       if (!envelope.Message) {
-        this.logger.warn('SNS Notification missing Message body — skipping');
+        this._logger.warn('SNS Notification missing Message body — skipping');
         return;
       }
 
@@ -113,19 +113,19 @@ export class SesWebhookController {
       try {
         notification = JSON.parse(envelope.Message) as SesNotification;
       } catch {
-        this.logger.error(
+        this._logger.error(
           'Failed to parse SES notification from SNS Message field',
         );
         return;
       }
 
-      await this.sesWebhookService.processNotification(
+      await this._sesWebhookService.processNotification(
         envelope.MessageId,
         notification,
       );
       return;
     }
 
-    this.logger.warn(`Unhandled SNS message type: ${type}`);
+    this._logger.warn(`Unhandled SNS message type: ${type}`);
   }
 }

--- a/src/webhooks/ses/ses-webhook.service.ts
+++ b/src/webhooks/ses/ses-webhook.service.ts
@@ -20,20 +20,20 @@ import {
 
 @Injectable()
 export class SesWebhookService {
-  private readonly logger = new Logger(SesWebhookService.name);
+  private readonly _logger = new Logger(SesWebhookService.name);
 
   /**
    * Creates an instance of SesWebhookService.
    *
-   * @param sesEventRepository - The ses event repository.
-   * @param configService - The config service.
-   * @param secretsService - The secrets service.
+   * @param _sesEventRepository - The ses event repository.
+   * @param _configService - The config service.
+   * @param _secretsService - The secrets service.
    */
   constructor(
     @InjectRepository(SesEventEntity)
-    private readonly sesEventRepository: Repository<SesEventEntity>,
-    private readonly configService: ConfigService,
-    private readonly secretsService: SecretsService,
+    private readonly _sesEventRepository: Repository<SesEventEntity>,
+    private readonly _configService: ConfigService,
+    private readonly _secretsService: SecretsService,
   ) {}
 
   // ---------------------------------------------------------------------------
@@ -54,7 +54,7 @@ export class SesWebhookService {
     try {
       parsed = new URL(subscribeUrl);
     } catch {
-      this.logger.error('Invalid SNS subscription URL format');
+      this._logger.error('Invalid SNS subscription URL format');
       return;
     }
 
@@ -68,13 +68,13 @@ export class SesWebhookService {
     const isInvalidPort = parsed.port && parsed.port !== '443';
 
     if (parsed.protocol !== 'https:' || !isAmazonSns || isInvalidPort) {
-      this.logger.error(
+      this._logger.error(
         'Rejected SNS confirmation: invalid protocol, domain, or port',
       );
       return;
     }
 
-    this.logger.log('Confirming SNS subscription via AWS endpoint');
+    this._logger.log('Confirming SNS subscription via AWS endpoint');
 
     // Use an options object to explicitly break the data flow into vetted parts.
     const options: https.RequestOptions = {
@@ -88,13 +88,13 @@ export class SesWebhookService {
     await new Promise<void>((resolve, reject) => {
       https
         .get(options, res => {
-          this.logger.log(
+          this._logger.log(
             `SNS subscription confirmed. HTTP status: ${res.statusCode}`,
           );
           resolve();
         })
         .on('error', err => {
-          this.logger.error('Failed to confirm SNS subscription', err.message);
+          this._logger.error('Failed to confirm SNS subscription', err.message);
           reject(err);
         });
     });
@@ -119,11 +119,11 @@ export class SesWebhookService {
     notification: SesNotification,
   ): Promise<void> {
     // Idempotency: skip if this SNS message has already been processed.
-    const existing = await this.sesEventRepository.findOne({
+    const existing = await this._sesEventRepository.findOne({
       where: { snsMessageId },
     });
     if (existing) {
-      this.logger.warn(
+      this._logger.warn(
         `Duplicate SNS message ${snsMessageId} — skipping (already persisted as event ${existing.id})`,
       );
       return;
@@ -143,7 +143,7 @@ export class SesWebhookService {
         await this.handleReject(snsMessageId, notification);
         break;
       default:
-        this.logger.warn(
+        this._logger.warn(
           `Unrecognised SES notification type: ${String(notification.notificationType)}`,
         );
     }
@@ -161,7 +161,7 @@ export class SesWebhookService {
    */
   async isSuppressed(email: string): Promise<boolean> {
     const hash = await this.hashEmail(email);
-    const count = await this.sesEventRepository.count({
+    const count = await this._sesEventRepository.count({
       where: { emailHashed: hash, suppress: true },
     });
     return count > 0;
@@ -180,7 +180,7 @@ export class SesWebhookService {
   validateTopicArn(envelope: SnsEnvelope): boolean {
     const expected = process.env.AWS_SNS_TOPIC_ARN;
     if (!expected) {
-      this.logger.error(
+      this._logger.error(
         'AWS_SNS_TOPIC_ARN is not configured — cannot validate SNS message origin',
       );
       return false;
@@ -225,16 +225,16 @@ export class SesWebhookService {
    * @returns A 64-character lowercase hexadecimal HMAC-SHA256 digest.
    */
   private async hashEmail(email: string): Promise<string> {
-    const secretName = this.configService.get<string>('AWS_SECRET_NAME');
+    const secretName = this._configService.get<string>('AWS_SECRET_NAME');
     let secret = '';
 
     if (secretName) {
-      const secretObject = await this.secretsService.getSecret(secretName);
+      const secretObject = await this._secretsService.getSecret(secretName);
       secret = secretObject?.sesEmailHmacSecret ?? '';
     }
 
     if (!secret) {
-      this.logger.warn(
+      this._logger.warn(
         'SES HMAC secret is not configured in Secrets Manager — email hashes will be computed with an empty key',
       );
     }
@@ -263,7 +263,7 @@ export class SesWebhookService {
 
     for (const recipient of bounce.bouncedRecipients) {
       const emailHashed = await this.hashEmail(recipient.emailAddress);
-      const event = this.sesEventRepository.create({
+      const event = this._sesEventRepository.create({
         eventType: 'Bounce',
         emailHashed,
         bounceType: bounce.bounceType as SesBounceType,
@@ -274,14 +274,14 @@ export class SesWebhookService {
         suppress: isPermanent,
       });
 
-      await this.sesEventRepository.save(event);
+      await this._sesEventRepository.save(event);
 
       if (isPermanent) {
-        this.logger.warn(
+        this._logger.warn(
           `Hard bounce (${bounce.bounceSubType}) recorded — address suppressed`,
         );
       } else {
-        this.logger.log(
+        this._logger.log(
           `Soft bounce (${bounce.bounceType}/${bounce.bounceSubType}) recorded — address not suppressed`,
         );
       }
@@ -306,7 +306,7 @@ export class SesWebhookService {
 
     for (const recipient of complaint.complainedRecipients) {
       const emailHashed = await this.hashEmail(recipient.emailAddress);
-      const event = this.sesEventRepository.create({
+      const event = this._sesEventRepository.create({
         eventType: 'Complaint',
         emailHashed,
         bounceType: null,
@@ -317,9 +317,9 @@ export class SesWebhookService {
         suppress: true,
       });
 
-      await this.sesEventRepository.save(event);
+      await this._sesEventRepository.save(event);
 
-      this.logger.warn(
+      this._logger.warn(
         `Complaint (${complaint.complaintFeedbackType ?? 'unknown feedback type'}) recorded — address suppressed`,
       );
     }
@@ -343,7 +343,7 @@ export class SesWebhookService {
 
     for (const recipient of delivery.recipients) {
       const emailHashed = await this.hashEmail(recipient);
-      const event = this.sesEventRepository.create({
+      const event = this._sesEventRepository.create({
         eventType: 'Delivery',
         emailHashed,
         bounceType: null,
@@ -354,10 +354,10 @@ export class SesWebhookService {
         suppress: false,
       });
 
-      await this.sesEventRepository.save(event);
+      await this._sesEventRepository.save(event);
     }
 
-    this.logger.log(
+    this._logger.log(
       `Delivery confirmed for ${delivery.recipients.length} recipient(s) in ${delivery.processingTimeMillis}ms`,
     );
   }
@@ -380,7 +380,7 @@ export class SesWebhookService {
     const reject = notification.reject;
     const emailHashed = await this.hashEmail(notification.mail.destination[0]);
 
-    const event = this.sesEventRepository.create({
+    const event = this._sesEventRepository.create({
       eventType: 'Bounce', // Record as a bounce for simplicity in lookups
       emailHashed,
       bounceType: 'Permanent',
@@ -392,9 +392,9 @@ export class SesWebhookService {
       reason: reject?.reason ?? 'SES_REJECTED',
     });
 
-    await this.sesEventRepository.save(event);
+    await this._sesEventRepository.save(event);
 
-    this.logger.warn(
+    this._logger.warn(
       `SES Reject recorded for ${notification.mail.destination[0]}: ${reject?.reason ?? 'unknown reason'}`,
     );
   }


### PR DESCRIPTION
## Description

Introduces and applies a new naming convention for `readonly` class properties and constructor parameters. This change enhances code consistency and readability by clearly distinguishing these members, thereby improving maintainability across the codebase. An `@typescript-eslint/naming-convention` ESLint rule now enforces that all `private`, `protected`, `static`, and `readonly` class properties and constructor parameters must be prefixed with an underscore. The codebase has been refactored to comply with this new standard.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [x] Documentation update
- [x] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [ ] I have added/updated tests to cover my changes.
- [x] I have updated the documentation where necessary.
- [ ] I have considered the security implications of these changes.
- [x] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

Relates to SC-374

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>