### PR TITLE
feat: Implements global logout and audit logging on password reset

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { AuditEntity } from 'src/audit/entities/audit.entity';
 import { AuditLoginAttemptEntity } from 'src/audit/entities/audit-login-attempt.entity';
 import { MailModule } from 'src/mail/mail.module';
 import { MailService } from 'src/mail/mail.service';
@@ -18,7 +19,7 @@ import { LocalStrategy } from './local.strategy';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([AuditLoginAttemptEntity]),
+    TypeOrmModule.forFeature([AuditEntity, AuditLoginAttemptEntity]),
     PassportModule,
     SharedModule,
     JwtModule.registerAsync({

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -12,6 +12,7 @@ import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import * as bcrypt from 'bcrypt';
+import { AuditEntity } from 'src/audit/entities/audit.entity';
 import { AuditLoginAttemptEntity } from 'src/audit/entities/audit-login-attempt.entity';
 import { MailService } from 'src/mail/mail.service';
 import { CurrentContextHelper } from 'src/shared/context/current-context.helper';
@@ -50,6 +51,7 @@ describe('AuthService', () => {
   let userRepository: Repository<UserEntity>;
   let userProfileRepository: Repository<UserProfileEntity>;
   let loginAttemptRepository: Repository<AuditLoginAttemptEntity>;
+  let auditRepository: Repository<AuditEntity>;
   let jwtService: JwtService;
   let userService: UserService;
   let mailService: MailService;
@@ -89,6 +91,12 @@ describe('AuthService', () => {
         },
         {
           provide: getRepositoryToken(AuditLoginAttemptEntity),
+          useValue: {
+            save: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(AuditEntity),
           useValue: {
             save: jest.fn(),
           },
@@ -135,6 +143,7 @@ describe('AuthService', () => {
     loginAttemptRepository = module.get(
       getRepositoryToken(AuditLoginAttemptEntity),
     );
+    auditRepository = module.get(getRepositoryToken(AuditEntity));
     jwtService = module.get(JwtService);
     userService = module.get(UserService);
     mailService = module.get(MailService);
@@ -681,6 +690,17 @@ describe('AuthService', () => {
 
       await service.resetPassword('token', 'newpass');
       expect(userRepository.save).toHaveBeenCalled();
+      expect(refreshTokenService.revokeAllTokensForUser).toHaveBeenCalledWith(
+        '1',
+      );
+      expect(auditRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entity: 'AuthSession',
+          action: 'PASSWORD_RESET_GLOBAL_LOGOUT',
+          entityId: '1',
+          userId: '1',
+        }),
+      );
       expect(mailService.sendPasswordChangedEmail).toHaveBeenCalledWith(
         expect.any(String),
         'Captain!',
@@ -702,6 +722,17 @@ describe('AuthService', () => {
       ).mockResolvedValue('hashed');
 
       await service.resetPassword('token', 'newpass');
+      expect(refreshTokenService.revokeAllTokensForUser).toHaveBeenCalledWith(
+        '1',
+      );
+      expect(auditRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entity: 'AuthSession',
+          action: 'PASSWORD_RESET_GLOBAL_LOGOUT',
+          entityId: '1',
+          userId: '1',
+        }),
+      );
       expect(mailService.sendPasswordChangedEmail).toHaveBeenCalledWith(
         expect.any(String),
         'Bones',

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -17,6 +17,7 @@ import * as ejs from 'ejs';
 import { convert as htmlToText } from 'html-to-text';
 import * as crypto from 'node:crypto';
 import * as path from 'node:path';
+import { AuditEntity } from 'src/audit/entities/audit.entity';
 import { AuditLoginAttemptEntity } from 'src/audit/entities/audit-login-attempt.entity';
 import { MailService } from 'src/mail/mail.service';
 import { EMAIL_PATTERN } from 'src/shared/constants/regex-patterns.constants';
@@ -58,6 +59,9 @@ export class AuthService {
 
     @InjectRepository(AuditLoginAttemptEntity)
     private readonly _loginAttemptRepository: Repository<AuditLoginAttemptEntity>,
+
+    @InjectRepository(AuditEntity)
+    private readonly _auditRepository: Repository<AuditEntity>,
 
     private readonly _jwtService: JwtService,
     private readonly _userService: UserService,
@@ -453,12 +457,13 @@ export class AuthService {
 
     await this._userRepository.save(user);
 
+    await this._refreshTokenService.revokeAllTokensForUser(user.id);
+    await this.logPasswordResetSessionInvalidation(user);
+
     await this._mailService.sendPasswordChangedEmail(
       user.email,
       user.profile?.firstName || 'Captain!',
     );
-
-    await this._refreshTokenService.revokeAllTokensForUser(user.id);
   }
 
   /**
@@ -662,5 +667,28 @@ export class AuthService {
   ): Promise<never> {
     await this.logLoginAttempt(email, ipAddress, false);
     throw new HttpException(message, status);
+  }
+
+  /**
+   * Creates an explicit security audit record when password reset invalidates all sessions.
+   */
+  private async logPasswordResetSessionInvalidation(
+    user: Pick<UserEntity, 'id' | 'email'>,
+  ): Promise<void> {
+    const audit = new AuditEntity();
+    audit.entity = 'AuthSession';
+    audit.action = 'PASSWORD_RESET_GLOBAL_LOGOUT';
+    audit.entityId = user.id;
+    audit.oldValue = null;
+    audit.newValue = {
+      reason: 'password_reset',
+      forcedReauthentication: true,
+      userEmail: user.email,
+    };
+    audit.userId = user.id;
+    audit.ipAddress = CurrentContextHelper.ip;
+
+    await validateOrReject(audit);
+    await this._auditRepository.save(audit);
   }
 }

--- a/src/user-refresh-token/user-refresh-token.service.spec.ts
+++ b/src/user-refresh-token/user-refresh-token.service.spec.ts
@@ -52,6 +52,7 @@ describe('UserRefreshTokenService', () => {
             findOne: jest.fn(),
             find: jest.fn(),
             update: jest.fn(),
+            delete: jest.fn(),
             createQueryBuilder: jest.fn().mockReturnValue({
               delete: jest.fn().mockReturnThis(),
               where: jest.fn().mockReturnThis(),
@@ -360,6 +361,7 @@ describe('UserRefreshTokenService', () => {
     it('should update all tokens for user', async () => {
       await service.revokeAllTokensForUser('u1');
       expect(repo.update).toHaveBeenCalled();
+      expect(repo.delete).toHaveBeenCalledWith({ userId: 'u1' });
     });
 
     it('should throw BadRequestException if userId is missing', async () => {

--- a/src/user-refresh-token/user-refresh-token.service.ts
+++ b/src/user-refresh-token/user-refresh-token.service.ts
@@ -261,9 +261,12 @@ export class UserRefreshTokenService {
     }
 
     await this._refreshTokenRepository.update(
-      { user: { id: userId }, isRevoked: false },
+      { userId, isRevoked: false },
       { isRevoked: true },
     );
+
+    // Clear persisted refresh tokens so all active sessions are forced to re-authenticate.
+    await this._refreshTokenRepository.delete({ userId });
   }
 
   /**

--- a/src/views/email-templates/password-changed-email.ejs
+++ b/src/views/email-templates/password-changed-email.ejs
@@ -4,6 +4,10 @@
   As requested, the <%= appTitle %> has reset your password.
 </p>
 
+<p>
+  For your security, all active sessions across your devices have been signed out. Please log in again with your new password.
+</p>
+
 <p></p><strong>Didn't request this change?</strong><br/>
 If you have not requested to reset your password, <a
 href="<%= contactUsUrl %>"


### PR DESCRIPTION
## Description

This change introduces a security enhancement that ensures all active user sessions are immediately invalidated when a user resets their password. This is achieved by revoking and then explicitly deleting all refresh tokens associated with the user, forcing a re-authentication across all devices.

A detailed audit record is now generated to explicitly log this forced global logout event, providing better security visibility. Additionally, the password changed email template is updated to clearly inform the user about the session invalidation and the requirement to log in again with their new password.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [x] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation where necessary.
- [x] I have considered the security implications of these changes.
- [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

Relates to SC-329

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>