### PR TITLE
feat(sto): adds character reputation tracking

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -35,6 +35,7 @@ import { AccountModule } from './sto/account/account.module';
 import { CharacterModule } from './sto/character/character.module';
 import { EndeavourModule } from './sto/endeavour/endeavour.module';
 import { LauncherModule } from './sto/launcher/launcher.module';
+import { CharacterReputationModule } from './sto/character-reputation/character-reputation.module';
 import { StatsModule } from './sto/stats/stats.module';
 import { PlatformLauncherModule } from './sto/platform-launcher/platform-launcher.module';
 import { PlatformModule } from './sto/platform/platform.module';
@@ -90,6 +91,7 @@ import { SesWebhookModule } from './webhooks/ses/ses-webhook.module';
     AccountModule,
     CharacterModule,
     EndeavourModule,
+    CharacterReputationModule,
     StatsModule,
     PlatformModule,
     LauncherModule,

--- a/src/database/migrations/1784160000000-CreateCharacterReputationTables.ts
+++ b/src/database/migrations/1784160000000-CreateCharacterReputationTables.ts
@@ -1,0 +1,97 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateCharacterReputationTables1784160000000 implements MigrationInterface {
+  name = 'CreateCharacterReputationTables1784160000000';
+
+  /**
+   * Applies the migration to the database.
+   *
+   * @param queryRunner - The TypeORM query runner.
+   */
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // --- character_reputation table ---
+    await queryRunner.query(`
+      CREATE TABLE "sto_info_app"."character_reputation" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "name" character varying(255) NOT NULL,
+        "description" text,
+        "iconUrl" character varying(512),
+        "accentColor" character varying(9),
+        "releasedWith" character varying(255),
+        "sortOrder" integer NOT NULL DEFAULT 0,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_character_reputation" PRIMARY KEY ("id"),
+        CONSTRAINT "UX_character_reputation_name" UNIQUE ("name")
+      )
+    `);
+
+    // --- character_reputation_progress table ---
+    await queryRunner.query(`
+      CREATE TABLE "sto_info_app"."character_reputation_progress" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "characterId" uuid NOT NULL,
+        "reputationId" uuid NOT NULL,
+        "currentTier" integer NOT NULL DEFAULT 0,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_character_reputation_progress" PRIMARY KEY ("id"),
+        CONSTRAINT "UX_character_reputation_progress_character_reputation" UNIQUE ("characterId", "reputationId"),
+        CONSTRAINT "CK_character_reputation_progress_tier" CHECK ("currentTier" >= 0 AND "currentTier" <= 6),
+        CONSTRAINT "FK_character_reputation_progress_character" FOREIGN KEY ("characterId")
+          REFERENCES "sto_info_app"."character"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+        CONSTRAINT "FK_character_reputation_progress_reputation" FOREIGN KEY ("reputationId")
+          REFERENCES "sto_info_app"."character_reputation"("id") ON DELETE CASCADE ON UPDATE CASCADE
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_character_reputation_progress_characterId"
+      ON "sto_info_app"."character_reputation_progress" ("characterId")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_character_reputation_progress_reputationId"
+      ON "sto_info_app"."character_reputation_progress" ("reputationId")
+    `);
+
+    // --- Seed: Reputations (13), ordered by in-game release ---
+    // Accent colours and mark icons mirror the STO wiki Reputation System cards.
+    await queryRunner.query(`
+      INSERT INTO "sto_info_app"."character_reputation"
+        ("name", "description", "iconUrl", "accentColor", "releasedWith", "sortOrder")
+      VALUES
+        ('Task Force Omega',              'Focused on combating the Borg threat in the Beta Quadrant.',                                          '/assets/reputations/omega.png',       '#1f6321', 'Season Seven: New Romulus',      10),
+        ('New Romulus',                   'Assists the Romulan Republic with the resettlement of New Romulus.',                                  '/assets/reputations/new-romulus.png', '#296361', 'Season Seven: New Romulus',      20),
+        ('Nukara Strikeforce',            'Dedicated to stopping Tholian incursions on Nukara Prime and beyond.',                                '/assets/reputations/nukara.png',      '#ada227', 'Legacy of Romulus',              30),
+        ('Dyson Joint Command',           'A joint task force exploring the Solanae Dyson Sphere and countering the Voth.',                      '/assets/reputations/dyson.png',       '#743c7d', 'Season Eight: The Sphere',       40),
+        ('8472 Counter-Command',          'Coordinates the defence against Species 8472 (the Undine) in fluidic space.',                         '/assets/reputations/undine.png',      '#b76e07', 'Season Nine: A New Accord',      50),
+        ('Delta Alliance',                'An alliance of Delta Quadrant powers united against the Vaadwaur.',                                   '/assets/reputations/delta.png',       '#992c13', 'Delta Rising',                   60),
+        ('Iconian Resistance',            'The combined effort to resist the Iconian invasion of the Alpha and Beta Quadrants.',                '/assets/reputations/iconian.png',     '#620c75', 'Season Ten: The Iconian War',    70),
+        ('Terran Task Force',             'Defends the Prime Universe against invasions by the Terran Empire.',                                  '/assets/reputations/terran.png',      '#ad8905', 'Season Eleven: New Dawn',        80),
+        ('Temporal Defense Initiative',   'Protects the timeline from temporal incursions and the Temporal Cold War.',                           '/assets/reputations/temporal.png',    '#067982', 'Agents of Yesterday',            90),
+        ('Lukari Restoration Initiative', 'Supports the Lukari as they reclaim their heritage and explore the galaxy.',                          '/assets/reputations/lukari.png',      '#5d4784', 'Season Twelve: Reckoning',       100),
+        ('Competitive Wargames',          'Sharpens combat readiness through competitive training exercises.',                                   '/assets/reputations/competitive.png', '#0c6396', 'Season Thirteen: Escalation',    110),
+        ('Gamma Task Force',              'Joint operations with the Dominion against the Hur''q threat in the Gamma Quadrant.',                '/assets/reputations/gamma.png',       '#7d037f', 'Victory is Life',                120),
+        ('Discovery Legends',             'Works alongside the crew of the U.S.S. Discovery to safeguard the galaxy.',                           '/assets/reputations/discovery.png',   '#c69f3b', 'Rise of Discovery',              130)
+    `);
+  }
+
+  /**
+   * Reverts the migration from the database.
+   *
+   * @param queryRunner - The TypeORM query runner.
+   */
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "sto_info_app"."IDX_character_reputation_progress_reputationId"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "sto_info_app"."IDX_character_reputation_progress_characterId"`,
+    );
+    await queryRunner.query(
+      `DROP TABLE "sto_info_app"."character_reputation_progress"`,
+    );
+    await queryRunner.query(`DROP TABLE "sto_info_app"."character_reputation"`);
+  }
+}

--- a/src/sto/character-reputation/character-reputation.controller.spec.ts
+++ b/src/sto/character-reputation/character-reputation.controller.spec.ts
@@ -1,0 +1,108 @@
+import { jest } from '@jest/globals';
+import { Test, TestingModule } from '@nestjs/testing';
+import { UpdateCharacterReputationProgressDto } from './dto/update-character-reputation-progress.dto';
+import { CharacterReputationController } from './character-reputation.controller';
+import { CharacterReputationService } from './character-reputation.service';
+
+describe('CharacterReputationController', () => {
+  let controller: CharacterReputationController;
+  let service: CharacterReputationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CharacterReputationController],
+      providers: [
+        {
+          provide: CharacterReputationService,
+          useValue: {
+            getReputations: jest.fn<(...args: any[]) => Promise<any>>(),
+            getProgress: jest.fn<(...args: any[]) => Promise<any>>(),
+            getSummary: jest.fn<(...args: any[]) => Promise<any>>(),
+            updateProgress: jest.fn<(...args: any[]) => Promise<any>>(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<CharacterReputationController>(
+      CharacterReputationController,
+    );
+    service = module.get<CharacterReputationService>(
+      CharacterReputationService,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should delegate getReputations to service', async () => {
+    (
+      service.getReputations as jest.Mock<(...args: any[]) => Promise<any>>
+    ).mockResolvedValue([{ id: 'rep-1' }]);
+
+    const result = await controller.getReputations();
+
+    expect(result).toEqual([{ id: 'rep-1' }]);
+    expect(service.getReputations).toHaveBeenCalledWith();
+  });
+
+  it('should delegate getProgress to service', async () => {
+    (
+      service.getProgress as jest.Mock<(...args: any[]) => Promise<any>>
+    ).mockResolvedValue([{ id: 'progress-1' }]);
+
+    const result = await controller.getProgress('user-1', 'character-1');
+
+    expect(result).toEqual([{ id: 'progress-1' }]);
+    expect(service.getProgress).toHaveBeenCalledWith('character-1', 'user-1');
+  });
+
+  it('should delegate getSummary to service', async () => {
+    const summary = {
+      totalTiers: 0,
+      maxPossibleTiers: 0,
+      overallCompletionPercentage: 0,
+      completedReputations: 0,
+      totalReputations: 0,
+    };
+    (
+      service.getSummary as jest.Mock<(...args: any[]) => Promise<any>>
+    ).mockResolvedValue(summary);
+
+    const result = await controller.getSummary('user-1', 'character-1');
+
+    expect(result).toEqual(summary);
+    expect(service.getSummary).toHaveBeenCalledWith('character-1', 'user-1');
+  });
+
+  it('should delegate updateProgress to service', async () => {
+    const dto: UpdateCharacterReputationProgressDto = {
+      currentTier: 4,
+    };
+    (
+      service.updateProgress as jest.Mock<(...args: any[]) => Promise<any>>
+    ).mockResolvedValue({
+      id: 'progress-1',
+    });
+
+    const result = await controller.updateProgress(
+      'user-1',
+      'character-1',
+      'rep-1',
+      dto,
+    );
+
+    expect(result).toEqual({ id: 'progress-1' });
+    expect(service.updateProgress).toHaveBeenCalledWith(
+      'character-1',
+      'user-1',
+      'rep-1',
+      dto,
+    );
+  });
+});

--- a/src/sto/character-reputation/character-reputation.controller.ts
+++ b/src/sto/character-reputation/character-reputation.controller.ts
@@ -1,0 +1,110 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { UserId } from 'src/auth/user-id.decorator';
+import { UpdateCharacterReputationProgressDto } from './dto/update-character-reputation-progress.dto';
+import { CharacterReputationService } from './character-reputation.service';
+
+@ApiTags('Character Reputation APIs')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('reputation')
+export class CharacterReputationController {
+  /**
+   * Creates an instance of CharacterReputationController.
+   *
+   * @param _reputationService - The reputation service.
+   */
+  constructor(
+    private readonly _reputationService: CharacterReputationService,
+  ) {}
+
+  @Get('list')
+  @ApiOkResponse({ description: 'Successfully retrieved reputations.' })
+  @HttpCode(HttpStatus.OK)
+  /**
+   * Gets the reputation catalog.
+   *
+   * @returns The result of the operation.
+   */
+  getReputations() {
+    return this._reputationService.getReputations();
+  }
+
+  @Get('character/:characterId')
+  @ApiOkResponse({ description: 'Successfully retrieved reputation progress.' })
+  @ApiBadRequestResponse({ description: 'Failed to retrieve progress.' })
+  @HttpCode(HttpStatus.OK)
+  /**
+   * Gets reputation progress.
+   *
+   * @param userId - The user id.
+   * @param characterId - The character id.
+   * @returns The result of the operation.
+   */
+  getProgress(
+    @UserId() userId: string,
+    @Param('characterId') characterId: string,
+  ) {
+    return this._reputationService.getProgress(characterId, userId);
+  }
+
+  @Get('character/:characterId/summary')
+  @ApiOkResponse({ description: 'Successfully retrieved reputation summary.' })
+  @ApiBadRequestResponse({ description: 'Failed to retrieve summary.' })
+  @HttpCode(HttpStatus.OK)
+  /**
+   * Gets the reputation summary.
+   *
+   * @param userId - The user id.
+   * @param characterId - The character id.
+   * @returns The result of the operation.
+   */
+  getSummary(
+    @UserId() userId: string,
+    @Param('characterId') characterId: string,
+  ) {
+    return this._reputationService.getSummary(characterId, userId);
+  }
+
+  @Put('character/:characterId/reputation/:reputationId')
+  @ApiOkResponse({ description: 'Successfully updated reputation progress.' })
+  @ApiBadRequestResponse({ description: 'Failed to update progress.' })
+  @HttpCode(HttpStatus.OK)
+  /**
+   * Updates reputation progress.
+   *
+   * @param userId - The user id.
+   * @param characterId - The character id.
+   * @param reputationId - The reputation id.
+   * @param dto - The dto.
+   * @returns The result of the operation.
+   */
+  updateProgress(
+    @UserId() userId: string,
+    @Param('characterId') characterId: string,
+    @Param('reputationId') reputationId: string,
+    @Body() dto: UpdateCharacterReputationProgressDto,
+  ) {
+    return this._reputationService.updateProgress(
+      characterId,
+      userId,
+      reputationId,
+      dto,
+    );
+  }
+}

--- a/src/sto/character-reputation/character-reputation.module.ts
+++ b/src/sto/character-reputation/character-reputation.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CharacterEntity } from 'src/sto/character/entities/character.entity';
+import { CharacterReputationProgressEntity } from './entities/character-reputation-progress.entity';
+import { CharacterReputationEntity } from './entities/character-reputation.entity';
+import { CharacterReputationController } from './character-reputation.controller';
+import { CharacterReputationService } from './character-reputation.service';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      CharacterReputationEntity,
+      CharacterReputationProgressEntity,
+      CharacterEntity,
+    ]),
+  ],
+  controllers: [CharacterReputationController],
+  providers: [CharacterReputationService],
+  exports: [CharacterReputationService],
+})
+export class CharacterReputationModule {}

--- a/src/sto/character-reputation/character-reputation.service.spec.ts
+++ b/src/sto/character-reputation/character-reputation.service.spec.ts
@@ -1,0 +1,262 @@
+import { jest } from '@jest/globals';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CharacterEntity } from 'src/sto/character/entities/character.entity';
+import { UpdateCharacterReputationProgressDto } from './dto/update-character-reputation-progress.dto';
+import { CharacterReputationProgressEntity } from './entities/character-reputation-progress.entity';
+import { CharacterReputationEntity } from './entities/character-reputation.entity';
+import { CharacterReputationService } from './character-reputation.service';
+
+describe('CharacterReputationService', () => {
+  let service: CharacterReputationService;
+
+  let reputationRepository: any;
+  let progressRepository: any;
+  let characterRepository: any;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CharacterReputationService,
+        {
+          provide: getRepositoryToken(CharacterReputationEntity),
+          useValue: {
+            find: jest.fn<(...args: any[]) => Promise<any>>(),
+            findOne: jest.fn<(...args: any[]) => Promise<any>>(),
+          },
+        },
+        {
+          provide: getRepositoryToken(CharacterReputationProgressEntity),
+          useValue: {
+            find: jest.fn<(...args: any[]) => Promise<any>>(),
+            findOne: jest.fn<(...args: any[]) => Promise<any>>(),
+            create: jest.fn<(...args: any[]) => any>(),
+            save: jest.fn<(...args: any[]) => Promise<any>>(),
+          },
+        },
+        {
+          provide: getRepositoryToken(CharacterEntity),
+          useValue: {
+            findOne: jest.fn<(...args: any[]) => Promise<any>>(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<CharacterReputationService>(
+      CharacterReputationService,
+    );
+    reputationRepository = module.get(
+      getRepositoryToken(CharacterReputationEntity),
+    );
+    progressRepository = module.get(
+      getRepositoryToken(CharacterReputationProgressEntity),
+    );
+    characterRepository = module.get(getRepositoryToken(CharacterEntity));
+
+    characterRepository.findOne.mockResolvedValue({
+      id: 'character-1',
+      account: { id: 'account-1', userId: 'user-1' },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getReputations', () => {
+    it('should query all reputations ordered by sortOrder then name', async () => {
+      reputationRepository.find.mockResolvedValue([{ id: 'rep-1' }]);
+
+      const result = await service.getReputations();
+
+      expect(result).toEqual([{ id: 'rep-1' }]);
+      expect(reputationRepository.find).toHaveBeenCalledWith({
+        order: { sortOrder: 'ASC', name: 'ASC' },
+      });
+    });
+  });
+
+  describe('getProgress', () => {
+    const reputations = [
+      { id: 'rep-a', name: 'Task Force Omega' },
+      { id: 'rep-b', name: 'New Romulus' },
+    ];
+
+    it('should throw NotFoundException when character does not exist', async () => {
+      characterRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.getProgress('missing-character', 'user-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ForbiddenException when character belongs to another user', async () => {
+      characterRepository.findOne.mockResolvedValue({
+        id: 'character-1',
+        account: { id: 'account-1', userId: 'other-user' },
+      });
+
+      await expect(
+        service.getProgress('character-1', 'user-1'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should return existing and synthetic entries for all reputations', async () => {
+      reputationRepository.find.mockResolvedValue(reputations);
+      progressRepository.find.mockResolvedValue([
+        {
+          id: 'progress-1',
+          characterId: 'character-1',
+          reputationId: 'rep-b',
+          reputation: { id: 'rep-b', name: 'New Romulus' },
+          currentTier: 4,
+        },
+      ]);
+
+      const result = await service.getProgress('character-1', 'user-1');
+
+      expect(result).toHaveLength(2);
+      expect(
+        result.find((item: any) => item.reputationId === 'rep-a'),
+      ).toMatchObject({
+        id: '',
+        characterId: 'character-1',
+        reputationId: 'rep-a',
+        currentTier: 0,
+      });
+      expect(
+        result.find((item: any) => item.reputationId === 'rep-b'),
+      ).toMatchObject({
+        id: 'progress-1',
+        currentTier: 4,
+      });
+      expect(progressRepository.find).toHaveBeenCalledWith({
+        where: { characterId: 'character-1' },
+        relations: { reputation: true },
+      });
+    });
+  });
+
+  describe('updateProgress', () => {
+    const dto: UpdateCharacterReputationProgressDto = { currentTier: 5 };
+
+    it('should throw NotFoundException when reputation does not exist', async () => {
+      reputationRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updateProgress('character-1', 'user-1', 'missing-rep', dto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should create and save a new progress record when one does not exist', async () => {
+      const reputation = {
+        id: 'rep-1',
+        name: 'Task Force Omega',
+      };
+      const created = {
+        id: 'progress-1',
+        characterId: 'character-1',
+        reputationId: 'rep-1',
+        currentTier: dto.currentTier,
+      };
+
+      reputationRepository.findOne.mockResolvedValue(reputation);
+      progressRepository.findOne.mockResolvedValue(null);
+      progressRepository.create.mockReturnValue(created);
+      progressRepository.save.mockResolvedValue(created);
+
+      const result = await service.updateProgress(
+        'character-1',
+        'user-1',
+        'rep-1',
+        dto,
+      );
+
+      expect(progressRepository.create).toHaveBeenCalledWith({
+        characterId: 'character-1',
+        reputationId: 'rep-1',
+        currentTier: 5,
+      });
+      expect(progressRepository.save).toHaveBeenCalledWith(created);
+      expect(result.reputation).toEqual(reputation);
+    });
+
+    it('should update and save an existing progress record', async () => {
+      const reputation = {
+        id: 'rep-2',
+        name: 'New Romulus',
+      };
+      const existing = {
+        id: 'progress-existing',
+        characterId: 'character-1',
+        reputationId: 'rep-2',
+        currentTier: 1,
+        reputation,
+      };
+
+      reputationRepository.findOne.mockResolvedValue(reputation);
+      progressRepository.findOne.mockResolvedValue(existing);
+      progressRepository.save.mockResolvedValue(existing);
+
+      const result = await service.updateProgress(
+        'character-1',
+        'user-1',
+        'rep-2',
+        { currentTier: 5 },
+      );
+
+      expect(progressRepository.create).not.toHaveBeenCalled();
+      expect(existing.currentTier).toBe(5);
+      expect(progressRepository.save).toHaveBeenCalledWith(existing);
+      expect(result.reputation).toEqual(reputation);
+    });
+  });
+
+  describe('getSummary', () => {
+    it('should return zero percentages when no reputations exist', async () => {
+      reputationRepository.find.mockResolvedValue([]);
+      progressRepository.find.mockResolvedValue([]);
+
+      const result = await service.getSummary('character-1', 'user-1');
+
+      expect(result).toEqual({
+        totalTiers: 0,
+        maxPossibleTiers: 0,
+        overallCompletionPercentage: 0,
+        completedReputations: 0,
+        totalReputations: 0,
+      });
+    });
+
+    it('should calculate totals, percentages, and completed reputations', async () => {
+      reputationRepository.find.mockResolvedValue([
+        { id: 'rep-1' },
+        { id: 'rep-2' },
+        { id: 'rep-3' },
+      ]);
+      progressRepository.find.mockResolvedValue([
+        { reputationId: 'rep-1', currentTier: 6 },
+        { reputationId: 'rep-2', currentTier: 3 },
+      ]);
+
+      const result = await service.getSummary('character-1', 'user-1');
+
+      expect(result).toEqual({
+        totalTiers: 9,
+        maxPossibleTiers: 18,
+        overallCompletionPercentage: 50,
+        completedReputations: 1,
+        totalReputations: 3,
+      });
+      expect(progressRepository.find).toHaveBeenCalledWith({
+        where: { characterId: 'character-1' },
+      });
+    });
+  });
+});

--- a/src/sto/character-reputation/character-reputation.service.ts
+++ b/src/sto/character-reputation/character-reputation.service.ts
@@ -1,0 +1,214 @@
+import {
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CharacterEntity } from 'src/sto/character/entities/character.entity';
+import { Repository } from 'typeorm';
+import { UpdateCharacterReputationProgressDto } from './dto/update-character-reputation-progress.dto';
+import { CharacterReputationProgressEntity } from './entities/character-reputation-progress.entity';
+import {
+  CharacterReputationEntity,
+  REPUTATION_MAX_TIER,
+} from './entities/character-reputation.entity';
+
+export interface CharacterReputationSummary {
+  totalTiers: number;
+  maxPossibleTiers: number;
+  overallCompletionPercentage: number;
+  completedReputations: number;
+  totalReputations: number;
+}
+
+@Injectable()
+export class CharacterReputationService {
+  /**
+   * Creates an instance of CharacterReputationService.
+   *
+   * @param _reputationRepository - The reputation repository.
+   * @param _progressRepository - The progress repository.
+   * @param _characterRepository - The character repository.
+   */
+  constructor(
+    @InjectRepository(CharacterReputationEntity)
+    private readonly _reputationRepository: Repository<CharacterReputationEntity>,
+    @InjectRepository(CharacterReputationProgressEntity)
+    private readonly _progressRepository: Repository<CharacterReputationProgressEntity>,
+    @InjectRepository(CharacterEntity)
+    private readonly _characterRepository: Repository<CharacterEntity>,
+  ) {}
+
+  /**
+   * Ensures the character belongs to the authenticated user.
+   *
+   * @param characterId - The character id.
+   * @param userId - The user id.
+   * @returns A promise that resolves when the operation completes.
+   */
+  private async requireOwnedCharacter(
+    characterId: string,
+    userId: string,
+  ): Promise<CharacterEntity> {
+    const character = await this._characterRepository.findOne({
+      where: { id: characterId },
+      relations: { account: true },
+    });
+
+    if (!character) {
+      throw new NotFoundException(
+        `Character with ID "${characterId}" not found`,
+      );
+    }
+
+    if (character.account?.userId !== userId) {
+      throw new ForbiddenException('You do not have access to this character');
+    }
+
+    return character;
+  }
+
+  /**
+   * Gets the reputation catalog.
+   *
+   * @returns A promise that resolves when the operation completes.
+   */
+  async getReputations(): Promise<CharacterReputationEntity[]> {
+    return this._reputationRepository.find({
+      order: { sortOrder: 'ASC', name: 'ASC' },
+    });
+  }
+
+  /**
+   * Gets reputation progress for a character.
+   *
+   * @param characterId - The character id.
+   * @param userId - The user id.
+   * @returns A promise that resolves when the operation completes.
+   */
+  async getProgress(
+    characterId: string,
+    userId: string,
+  ): Promise<CharacterReputationProgressEntity[]> {
+    await this.requireOwnedCharacter(characterId, userId);
+
+    const allReputations = await this.getReputations();
+
+    const existingProgress = await this._progressRepository.find({
+      where: { characterId },
+      relations: { reputation: true },
+    });
+
+    const progressMap = new Map(existingProgress.map(p => [p.reputationId, p]));
+
+    // Return one record per reputation, synthesising zero-progress entries for untracked reputations
+    return allReputations.map(reputation => {
+      const existing = progressMap.get(reputation.id);
+      if (existing) {
+        return existing;
+      }
+
+      const synthetic = new CharacterReputationProgressEntity();
+      synthetic.id = '';
+      synthetic.characterId = characterId;
+      synthetic.reputationId = reputation.id;
+      synthetic.reputation = reputation;
+      synthetic.currentTier = 0;
+      return synthetic;
+    });
+  }
+
+  /**
+   * Updates reputation progress for a character.
+   *
+   * @param characterId - The character id.
+   * @param userId - The user id.
+   * @param reputationId - The reputation id.
+   * @param dto - The dto.
+   * @returns A promise that resolves when the operation completes.
+   */
+  async updateProgress(
+    characterId: string,
+    userId: string,
+    reputationId: string,
+    dto: UpdateCharacterReputationProgressDto,
+  ): Promise<CharacterReputationProgressEntity> {
+    await this.requireOwnedCharacter(characterId, userId);
+
+    const reputation = await this._reputationRepository.findOne({
+      where: { id: reputationId },
+    });
+    if (!reputation) {
+      throw new NotFoundException(
+        `Reputation with ID "${reputationId}" not found`,
+      );
+    }
+
+    let progress = await this._progressRepository.findOne({
+      where: { characterId, reputationId },
+      relations: { reputation: true },
+    });
+
+    if (!progress) {
+      progress = this._progressRepository.create({
+        characterId,
+        reputationId,
+        currentTier: dto.currentTier,
+      });
+    } else {
+      progress.currentTier = dto.currentTier;
+    }
+
+    await this._progressRepository.save(progress);
+
+    progress.reputation = reputation;
+    return progress;
+  }
+
+  /**
+   * Gets the reputation summary for a character.
+   *
+   * @param characterId - The character id.
+   * @param userId - The user id.
+   * @returns A promise that resolves when the operation completes.
+   */
+  async getSummary(
+    characterId: string,
+    userId: string,
+  ): Promise<CharacterReputationSummary> {
+    await this.requireOwnedCharacter(characterId, userId);
+
+    const allReputations = await this._reputationRepository.find();
+    const existingProgress = await this._progressRepository.find({
+      where: { characterId },
+    });
+
+    const progressMap = new Map(existingProgress.map(p => [p.reputationId, p]));
+
+    let totalTiers = 0;
+    let completedReputations = 0;
+
+    for (const reputation of allReputations) {
+      const progress = progressMap.get(reputation.id);
+      const tier = progress?.currentTier ?? 0;
+      totalTiers += tier;
+
+      if (tier >= REPUTATION_MAX_TIER) {
+        completedReputations++;
+      }
+    }
+
+    const maxPossibleTiers = allReputations.length * REPUTATION_MAX_TIER;
+
+    return {
+      totalTiers,
+      maxPossibleTiers,
+      overallCompletionPercentage:
+        maxPossibleTiers > 0
+          ? Math.round((totalTiers / maxPossibleTiers) * 100)
+          : 0,
+      completedReputations,
+      totalReputations: allReputations.length,
+    };
+  }
+}

--- a/src/sto/character-reputation/dto/update-character-reputation-progress.dto.ts
+++ b/src/sto/character-reputation/dto/update-character-reputation-progress.dto.ts
@@ -1,0 +1,9 @@
+import { IsInt, Max, Min } from 'class-validator';
+import { REPUTATION_MAX_TIER } from '../entities/character-reputation.entity';
+
+export class UpdateCharacterReputationProgressDto {
+  @IsInt()
+  @Min(0)
+  @Max(REPUTATION_MAX_TIER)
+  currentTier: number;
+}

--- a/src/sto/character-reputation/entities/character-reputation-progress.entity.ts
+++ b/src/sto/character-reputation/entities/character-reputation-progress.entity.ts
@@ -1,0 +1,80 @@
+import { Expose } from 'class-transformer';
+import { IsInt, IsUUID, Max, Min } from 'class-validator';
+import { CharacterEntity } from 'src/sto/character/entities/character.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import {
+  CharacterReputationEntity,
+  REPUTATION_MAX_TIER,
+} from './character-reputation.entity';
+
+@Entity({ name: 'character_reputation_progress' })
+@Index(
+  'UX_character_reputation_progress_character_reputation',
+  ['characterId', 'reputationId'],
+  {
+    unique: true,
+  },
+)
+export class CharacterReputationProgressEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @IsUUID()
+  @Column({ type: 'uuid', nullable: false })
+  characterId: string;
+
+  @IsUUID()
+  @Column({ type: 'uuid', nullable: false })
+  reputationId: string;
+
+  @IsInt()
+  @Min(0)
+  @Max(REPUTATION_MAX_TIER)
+  @Column({ type: 'int', default: 0, nullable: false })
+  currentTier: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @ManyToOne('CharacterEntity', { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'characterId' })
+  character: CharacterEntity;
+
+  @ManyToOne('CharacterReputationEntity', { eager: true, onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'reputationId' })
+  reputation: CharacterReputationEntity;
+
+  @Expose()
+  /**
+   * Gets the progress status.
+   *
+   * @returns The result of the operation.
+   */
+  get status(): 'not_started' | 'in_progress' | 'complete' {
+    if (this.currentTier === 0) return 'not_started';
+    if (this.currentTier >= REPUTATION_MAX_TIER) return 'complete';
+    return 'in_progress';
+  }
+
+  @Expose()
+  /**
+   * Gets the completion percentage.
+   *
+   * @returns The result of the operation.
+   */
+  get completionPercentage(): number {
+    return Math.round((this.currentTier / REPUTATION_MAX_TIER) * 100);
+  }
+}

--- a/src/sto/character-reputation/entities/character-reputation.entity.ts
+++ b/src/sto/character-reputation/entities/character-reputation.entity.ts
@@ -1,0 +1,63 @@
+import { IsInt, IsNotEmpty, IsOptional, IsString, Min } from 'class-validator';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { CharacterReputationProgressEntity } from './character-reputation-progress.entity';
+
+/** The maximum reputation tier a character can attain. */
+export const REPUTATION_MAX_TIER = 6;
+
+@Entity({ name: 'character_reputation' })
+@Index('UX_character_reputation_name', ['name'], { unique: true })
+export class CharacterReputationEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @IsNotEmpty()
+  @IsString()
+  @Column({ type: 'varchar', length: 255, nullable: false })
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  @Column({ type: 'text', nullable: true })
+  description: string | null;
+
+  @IsOptional()
+  @IsString()
+  @Column({ type: 'varchar', length: 512, nullable: true })
+  iconUrl: string | null;
+
+  @IsOptional()
+  @IsString()
+  @Column({ type: 'varchar', length: 9, nullable: true })
+  accentColor: string | null;
+
+  @IsOptional()
+  @IsString()
+  @Column({ type: 'varchar', length: 255, nullable: true })
+  releasedWith: string | null;
+
+  @IsInt()
+  @Min(0)
+  @Column({ type: 'int', default: 0, nullable: false })
+  sortOrder: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @OneToMany(
+    'CharacterReputationProgressEntity',
+    (progress: CharacterReputationProgressEntity) => progress.reputation,
+  )
+  characterProgress: CharacterReputationProgressEntity[];
+}


### PR DESCRIPTION
## Description

This pull request introduces a new module to enable tracking of Star Trek Online (STO) character reputations. It provides a comprehensive solution for managing reputation data and character progress:

-   A database migration creates `character_reputation` and `character_reputation_progress` tables, pre-populating the former with a catalogue of 13 STO reputations.
-   New TypeORM entities (`CharacterReputationEntity` and `CharacterReputationProgressEntity`) define the data models, including validation and computed properties for progress status and completion percentage.
-   A dedicated service (`CharacterReputationService`) handles business logic, including fetching reputation lists, retrieving individual character progress (synthesising entries for untracked reputations), updating progress for specific reputations, and calculating overall character reputation summaries.
-   A RESTful API controller (`CharacterReputationController`) exposes endpoints for interacting with the reputation system, secured with JWT authentication and character ownership checks.
-   Comprehensive unit tests for both the service and controller ensure the reliability and correctness of the new functionality.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [x] I have added/updated tests to cover my changes.
- [x] I have updated the documentation where necessary.
- [x] I have considered the security implications of these changes.
- [x] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

Relates to SC-1031

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>