### PR TITLE
feat(sto-character): add character specialization tracking

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -37,6 +37,7 @@ import { EndeavourModule } from './sto/endeavour/endeavour.module';
 import { LauncherModule } from './sto/launcher/launcher.module';
 import { CharacterReputationModule } from './sto/character-reputation/character-reputation.module';
 import { CharacterRdModule } from './sto/character-rd/character-rd.module';
+import { CharacterSpecializationModule } from './sto/character-specialization/character-specialization.module';
 import { StatsModule } from './sto/stats/stats.module';
 import { PlatformLauncherModule } from './sto/platform-launcher/platform-launcher.module';
 import { PlatformModule } from './sto/platform/platform.module';
@@ -94,6 +95,7 @@ import { SesWebhookModule } from './webhooks/ses/ses-webhook.module';
     EndeavourModule,
     CharacterReputationModule,
     CharacterRdModule,
+    CharacterSpecializationModule,
     StatsModule,
     PlatformModule,
     LauncherModule,

--- a/src/database/migrations/1785024000000-CreateCharacterSpecializationTables.ts
+++ b/src/database/migrations/1785024000000-CreateCharacterSpecializationTables.ts
@@ -25,7 +25,7 @@ export class CreateCharacterSpecializationTables1785024000000 implements Migrati
         CONSTRAINT "PK_character_specialization" PRIMARY KEY ("id"),
         CONSTRAINT "UX_character_specialization_name" UNIQUE ("name"),
         CONSTRAINT "CK_character_specialization_type" CHECK ("type" IN ('primary', 'secondary')),
-        CONSTRAINT "CK_character_specialization_max_points" CHECK ("maxPoints" > 0 AND "maxPoints" <= 30)
+        CONSTRAINT "CK_character_specialization_max_points" CHECK (("type" = 'primary' AND "maxPoints" > 0 AND "maxPoints" <= 30) OR ("type" = 'secondary' AND "maxPoints" > 0 AND "maxPoints" <= 15))
       )
     `);
 

--- a/src/database/migrations/1785024000000-CreateCharacterSpecializationTables.ts
+++ b/src/database/migrations/1785024000000-CreateCharacterSpecializationTables.ts
@@ -1,0 +1,114 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateCharacterSpecializationTables1785024000000 implements MigrationInterface {
+  name = 'CreateCharacterSpecializationTables1785024000000';
+
+  /**
+   * Applies the migration to the database.
+   *
+   * @param queryRunner - The TypeORM query runner.
+   */
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // --- character_specialization table ---
+    await queryRunner.query(`
+      CREATE TABLE "sto_info_app"."character_specialization" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "name" character varying(255) NOT NULL,
+        "description" text,
+        "iconUrl" character varying(512),
+        "accentColor" character varying(9),
+        "type" character varying(16) NOT NULL,
+        "maxPoints" integer NOT NULL DEFAULT 30,
+        "sortOrder" integer NOT NULL DEFAULT 0,
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_character_specialization" PRIMARY KEY ("id"),
+        CONSTRAINT "UX_character_specialization_name" UNIQUE ("name"),
+        CONSTRAINT "CK_character_specialization_type" CHECK ("type" IN ('primary', 'secondary')),
+        CONSTRAINT "CK_character_specialization_max_points" CHECK ("maxPoints" > 0 AND "maxPoints" <= 30)
+      )
+    `);
+
+    // --- character_specialization_progress table ---
+    await queryRunner.query(`
+      CREATE TABLE "sto_info_app"."character_specialization_progress" (
+        "id" uuid NOT NULL DEFAULT gen_random_uuid(),
+        "characterId" uuid NOT NULL,
+        "specializationId" uuid NOT NULL,
+        "pointsSpent" integer NOT NULL DEFAULT 0,
+        "slot" character varying(16),
+        "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+        "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_character_specialization_progress" PRIMARY KEY ("id"),
+        CONSTRAINT "UX_character_specialization_progress_character_specialization" UNIQUE ("characterId", "specializationId"),
+        CONSTRAINT "CK_character_specialization_progress_points" CHECK ("pointsSpent" >= 0 AND "pointsSpent" <= 30),
+        CONSTRAINT "CK_character_specialization_progress_slot" CHECK ("slot" IS NULL OR "slot" IN ('primary', 'secondary')),
+        CONSTRAINT "FK_character_specialization_progress_character" FOREIGN KEY ("characterId")
+          REFERENCES "sto_info_app"."character"("id") ON DELETE CASCADE ON UPDATE CASCADE,
+        CONSTRAINT "FK_character_specialization_progress_specialization" FOREIGN KEY ("specializationId")
+          REFERENCES "sto_info_app"."character_specialization"("id") ON DELETE CASCADE ON UPDATE CASCADE
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_character_specialization_progress_characterId"
+      ON "sto_info_app"."character_specialization_progress" ("characterId")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX "IDX_character_specialization_progress_specializationId"
+      ON "sto_info_app"."character_specialization_progress" ("specializationId")
+    `);
+
+    // A captain has at most one active Primary and one active Secondary
+    // specialization; every other tracked specialization has a NULL slot.
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "UX_character_specialization_progress_character_slot"
+      ON "sto_info_app"."character_specialization_progress" ("characterId", "slot")
+      WHERE "slot" IS NOT NULL
+    `);
+
+    // --- Seed: captain specializations ---
+    // Primary specializations offer 30 purchasable abilities and can be slotted
+    // as Primary or Secondary; secondary-only specializations offer 15 and can
+    // only be slotted as Secondary. 5 x 30 + 3 x 15 = 195 points in total.
+    // Icons mirror the STO wiki specialization icons (bundled under
+    // /assets/specializations).
+    await queryRunner.query(`
+      INSERT INTO "sto_info_app"."character_specialization"
+        ("name", "description", "iconUrl", "accentColor", "type", "maxPoints", "sortOrder")
+      VALUES
+        ('Command Officer',    'Leadership and coordination bonuses that improve the effectiveness of your team, in space and on the ground.', '/assets/specializations/command.png',            '#d4a017', 'primary',   30, 10),
+        ('Intelligence Officer','Exposing enemy weaknesses and staying undetected, while countering foes who try the same.',                    '/assets/specializations/intelligence.png',       '#16a085', 'primary',   30, 20),
+        ('Miracle Worker',     'Creative engineering solutions that push equipment past its documented limitations.',                          '/assets/specializations/miracle-worker.png',     '#e67e22', 'primary',   30, 30),
+        ('Pilot',              'Pushing the upper limits of starship manoeuvrability with evasive flying and attack patterns.',                '/assets/specializations/pilot.png',              '#2980b9', 'primary',   30, 40),
+        ('Temporal Operative', 'Manipulating the fabric of reality to turn probability and causality to your advantage.',                      '/assets/specializations/temporal-operative.png', '#8e44ad', 'primary',   30, 50),
+        ('Commando',           'Ground assault training that makes the most of your personal weaponry and equipment.',                         '/assets/specializations/commando.png',           '#c0392b', 'secondary', 15, 60),
+        ('Constable',          'Law-enforcement tactics centred on singling out and pursuing your Antagonist.',                                '/assets/specializations/constable.png',          '#0f7b8a', 'secondary', 15, 70),
+        ('Strategist',         'Battlefield plans that adapt to the changing conditions of multi-ship combat.',                                '/assets/specializations/strategist.png',         '#7f8c8d', 'secondary', 15, 80)
+    `);
+  }
+
+  /**
+   * Reverts the migration from the database.
+   *
+   * @param queryRunner - The TypeORM query runner.
+   */
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "sto_info_app"."UX_character_specialization_progress_character_slot"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "sto_info_app"."IDX_character_specialization_progress_specializationId"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "sto_info_app"."IDX_character_specialization_progress_characterId"`,
+    );
+    await queryRunner.query(
+      `DROP TABLE "sto_info_app"."character_specialization_progress"`,
+    );
+    await queryRunner.query(
+      `DROP TABLE "sto_info_app"."character_specialization"`,
+    );
+  }
+}

--- a/src/sto/character-specialization/character-specialization.controller.spec.ts
+++ b/src/sto/character-specialization/character-specialization.controller.spec.ts
@@ -1,0 +1,138 @@
+import { jest } from '@jest/globals';
+import { Test, TestingModule } from '@nestjs/testing';
+import { CharacterSpecializationController } from './character-specialization.controller';
+import { CharacterSpecializationService } from './character-specialization.service';
+import { UpdateCharacterSpecializationProgressDto } from './dto/update-character-specialization-progress.dto';
+import { UpdateCharacterSpecializationSlotDto } from './dto/update-character-specialization-slot.dto';
+
+describe('CharacterSpecializationController', () => {
+  let controller: CharacterSpecializationController;
+  let service: CharacterSpecializationService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CharacterSpecializationController],
+      providers: [
+        {
+          provide: CharacterSpecializationService,
+          useValue: {
+            getSpecializations: jest.fn<(...args: any[]) => Promise<any>>(),
+            getProgress: jest.fn<(...args: any[]) => Promise<any>>(),
+            getSummary: jest.fn<(...args: any[]) => Promise<any>>(),
+            updateProgress: jest.fn<(...args: any[]) => Promise<any>>(),
+            updateSlot: jest.fn<(...args: any[]) => Promise<any>>(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<CharacterSpecializationController>(
+      CharacterSpecializationController,
+    );
+    service = module.get<CharacterSpecializationService>(
+      CharacterSpecializationService,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should delegate getSpecializations to service', async () => {
+    (
+      service.getSpecializations as jest.Mock<(...args: any[]) => Promise<any>>
+    ).mockResolvedValue([{ id: 'spec-1' }]);
+
+    const result = await controller.getSpecializations();
+
+    expect(result).toEqual([{ id: 'spec-1' }]);
+    expect(service.getSpecializations).toHaveBeenCalledWith();
+  });
+
+  it('should delegate getProgress to service', async () => {
+    (
+      service.getProgress as jest.Mock<(...args: any[]) => Promise<any>>
+    ).mockResolvedValue([{ id: 'progress-1' }]);
+
+    const result = await controller.getProgress('user-1', 'character-1');
+
+    expect(result).toEqual([{ id: 'progress-1' }]);
+    expect(service.getProgress).toHaveBeenCalledWith('character-1', 'user-1');
+  });
+
+  it('should delegate getSummary to service', async () => {
+    const summary = {
+      totalPoints: 0,
+      maxPossiblePoints: 0,
+      overallCompletionPercentage: 0,
+      completedSpecializations: 0,
+      totalSpecializations: 0,
+      primarySpecializationName: null,
+      secondarySpecializationName: null,
+    };
+    (
+      service.getSummary as jest.Mock<(...args: any[]) => Promise<any>>
+    ).mockResolvedValue(summary);
+
+    const result = await controller.getSummary('user-1', 'character-1');
+
+    expect(result).toEqual(summary);
+    expect(service.getSummary).toHaveBeenCalledWith('character-1', 'user-1');
+  });
+
+  it('should delegate updateProgress to service', async () => {
+    const dto: UpdateCharacterSpecializationProgressDto = {
+      pointsSpent: 12,
+    };
+    (
+      service.updateProgress as jest.Mock<(...args: any[]) => Promise<any>>
+    ).mockResolvedValue({
+      id: 'progress-1',
+    });
+
+    const result = await controller.updateProgress(
+      'user-1',
+      'character-1',
+      'spec-1',
+      dto,
+    );
+
+    expect(result).toEqual({ id: 'progress-1' });
+    expect(service.updateProgress).toHaveBeenCalledWith(
+      'character-1',
+      'user-1',
+      'spec-1',
+      dto,
+    );
+  });
+
+  it('should delegate updateSlot to service', async () => {
+    const dto: UpdateCharacterSpecializationSlotDto = {
+      slot: 'primary',
+    };
+    (
+      service.updateSlot as jest.Mock<(...args: any[]) => Promise<any>>
+    ).mockResolvedValue({
+      id: 'progress-1',
+    });
+
+    const result = await controller.updateSlot(
+      'user-1',
+      'character-1',
+      'spec-1',
+      dto,
+    );
+
+    expect(result).toEqual({ id: 'progress-1' });
+    expect(service.updateSlot).toHaveBeenCalledWith(
+      'character-1',
+      'user-1',
+      'spec-1',
+      dto,
+    );
+  });
+});

--- a/src/sto/character-specialization/character-specialization.controller.ts
+++ b/src/sto/character-specialization/character-specialization.controller.ts
@@ -1,0 +1,144 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Put,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBadRequestResponse,
+  ApiBearerAuth,
+  ApiOkResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/jwt-auth.guard';
+import { UserId } from 'src/auth/user-id.decorator';
+import { CharacterSpecializationService } from './character-specialization.service';
+import { UpdateCharacterSpecializationProgressDto } from './dto/update-character-specialization-progress.dto';
+import { UpdateCharacterSpecializationSlotDto } from './dto/update-character-specialization-slot.dto';
+
+@ApiTags('Character Specialization APIs')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('specialization')
+export class CharacterSpecializationController {
+  /**
+   * Creates an instance of CharacterSpecializationController.
+   *
+   * @param _specializationService - The specialization service.
+   */
+  constructor(
+    private readonly _specializationService: CharacterSpecializationService,
+  ) {}
+
+  @Get('list')
+  @ApiOkResponse({ description: 'Successfully retrieved specializations.' })
+  @HttpCode(HttpStatus.OK)
+  /**
+   * Gets the captain specialization catalog.
+   *
+   * @returns The result of the operation.
+   */
+  getSpecializations() {
+    return this._specializationService.getSpecializations();
+  }
+
+  @Get('character/:characterId/summary')
+  @ApiOkResponse({
+    description: 'Successfully retrieved specialization summary.',
+  })
+  @ApiBadRequestResponse({ description: 'Failed to retrieve summary.' })
+  @HttpCode(HttpStatus.OK)
+  /**
+   * Gets the specialization summary.
+   *
+   * @param userId - The user id.
+   * @param characterId - The character id.
+   * @returns The result of the operation.
+   */
+  getSummary(
+    @UserId() userId: string,
+    @Param('characterId') characterId: string,
+  ) {
+    return this._specializationService.getSummary(characterId, userId);
+  }
+
+  @Get('character/:characterId')
+  @ApiOkResponse({
+    description: 'Successfully retrieved specialization progress.',
+  })
+  @ApiBadRequestResponse({ description: 'Failed to retrieve progress.' })
+  @HttpCode(HttpStatus.OK)
+  /**
+   * Gets specialization progress.
+   *
+   * @param userId - The user id.
+   * @param characterId - The character id.
+   * @returns The result of the operation.
+   */
+  getProgress(
+    @UserId() userId: string,
+    @Param('characterId') characterId: string,
+  ) {
+    return this._specializationService.getProgress(characterId, userId);
+  }
+
+  @Put('character/:characterId/specialization/:specializationId')
+  @ApiOkResponse({
+    description: 'Successfully updated specialization progress.',
+  })
+  @ApiBadRequestResponse({ description: 'Failed to update progress.' })
+  @HttpCode(HttpStatus.OK)
+  /**
+   * Updates the points spent in a specialization.
+   *
+   * @param userId - The user id.
+   * @param characterId - The character id.
+   * @param specializationId - The specialization id.
+   * @param dto - The dto.
+   * @returns The result of the operation.
+   */
+  updateProgress(
+    @UserId() userId: string,
+    @Param('characterId') characterId: string,
+    @Param('specializationId') specializationId: string,
+    @Body() dto: UpdateCharacterSpecializationProgressDto,
+  ) {
+    return this._specializationService.updateProgress(
+      characterId,
+      userId,
+      specializationId,
+      dto,
+    );
+  }
+
+  @Put('character/:characterId/specialization/:specializationId/slot')
+  @ApiOkResponse({ description: 'Successfully updated specialization slot.' })
+  @ApiBadRequestResponse({ description: 'Failed to update slot.' })
+  @HttpCode(HttpStatus.OK)
+  /**
+   * Activates or deactivates a specialization in a captain slot.
+   *
+   * @param userId - The user id.
+   * @param characterId - The character id.
+   * @param specializationId - The specialization id.
+   * @param dto - The dto.
+   * @returns The result of the operation.
+   */
+  updateSlot(
+    @UserId() userId: string,
+    @Param('characterId') characterId: string,
+    @Param('specializationId') specializationId: string,
+    @Body() dto: UpdateCharacterSpecializationSlotDto,
+  ) {
+    return this._specializationService.updateSlot(
+      characterId,
+      userId,
+      specializationId,
+      dto,
+    );
+  }
+}

--- a/src/sto/character-specialization/character-specialization.module.ts
+++ b/src/sto/character-specialization/character-specialization.module.ts
@@ -1,0 +1,21 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CharacterModule } from 'src/sto/character/character.module';
+import { CharacterSpecializationController } from './character-specialization.controller';
+import { CharacterSpecializationService } from './character-specialization.service';
+import { CharacterSpecializationProgressEntity } from './entities/character-specialization-progress.entity';
+import { CharacterSpecializationEntity } from './entities/character-specialization.entity';
+
+@Module({
+  imports: [
+    CharacterModule,
+    TypeOrmModule.forFeature([
+      CharacterSpecializationEntity,
+      CharacterSpecializationProgressEntity,
+    ]),
+  ],
+  controllers: [CharacterSpecializationController],
+  providers: [CharacterSpecializationService],
+  exports: [CharacterSpecializationService],
+})
+export class CharacterSpecializationModule {}

--- a/src/sto/character-specialization/character-specialization.service.spec.ts
+++ b/src/sto/character-specialization/character-specialization.service.spec.ts
@@ -41,6 +41,9 @@ describe('CharacterSpecializationService', () => {
             create: jest.fn<(...args: any[]) => any>(),
             save: jest.fn<(...args: any[]) => Promise<any>>(),
             update: jest.fn<(...args: any[]) => Promise<any>>(),
+            manager: {
+              transaction: jest.fn<(...args: any[]) => Promise<any>>(),
+            },
           },
         },
         {
@@ -67,6 +70,15 @@ describe('CharacterSpecializationService', () => {
       id: 'character-1',
       account: { id: 'account-1', userId: 'user-1' },
     });
+
+    progressRepository.manager.transaction.mockImplementation(
+      async (callback: (manager: any) => Promise<any>) =>
+        callback({
+          getRepository: jest
+            .fn<(...args: any[]) => any>()
+            .mockReturnValue(progressRepository),
+        }),
+    );
   });
 
   afterEach(() => {
@@ -314,6 +326,7 @@ describe('CharacterSpecializationService', () => {
         },
         { slot: null },
       );
+      expect(progressRepository.manager.transaction).toHaveBeenCalledTimes(1);
       expect(result.slot).toBe('primary');
       expect(progressRepository.save).toHaveBeenCalledWith(existing);
     });

--- a/src/sto/character-specialization/character-specialization.service.spec.ts
+++ b/src/sto/character-specialization/character-specialization.service.spec.ts
@@ -1,0 +1,397 @@
+import { jest } from '@jest/globals';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { CharacterOwnershipService } from 'src/sto/character/character-ownership.service';
+import { CharacterEntity } from 'src/sto/character/entities/character.entity';
+import { Not } from 'typeorm';
+import { CharacterSpecializationService } from './character-specialization.service';
+import { UpdateCharacterSpecializationProgressDto } from './dto/update-character-specialization-progress.dto';
+import { CharacterSpecializationProgressEntity } from './entities/character-specialization-progress.entity';
+import { CharacterSpecializationEntity } from './entities/character-specialization.entity';
+
+describe('CharacterSpecializationService', () => {
+  let service: CharacterSpecializationService;
+
+  let specializationRepository: any;
+  let progressRepository: any;
+  let characterRepository: any;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CharacterSpecializationService,
+        CharacterOwnershipService,
+        {
+          provide: getRepositoryToken(CharacterSpecializationEntity),
+          useValue: {
+            find: jest.fn<(...args: any[]) => Promise<any>>(),
+            findOne: jest.fn<(...args: any[]) => Promise<any>>(),
+          },
+        },
+        {
+          provide: getRepositoryToken(CharacterSpecializationProgressEntity),
+          useValue: {
+            find: jest.fn<(...args: any[]) => Promise<any>>(),
+            findOne: jest.fn<(...args: any[]) => Promise<any>>(),
+            create: jest.fn<(...args: any[]) => any>(),
+            save: jest.fn<(...args: any[]) => Promise<any>>(),
+            update: jest.fn<(...args: any[]) => Promise<any>>(),
+          },
+        },
+        {
+          provide: getRepositoryToken(CharacterEntity),
+          useValue: {
+            findOne: jest.fn<(...args: any[]) => Promise<any>>(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<CharacterSpecializationService>(
+      CharacterSpecializationService,
+    );
+    specializationRepository = module.get(
+      getRepositoryToken(CharacterSpecializationEntity),
+    );
+    progressRepository = module.get(
+      getRepositoryToken(CharacterSpecializationProgressEntity),
+    );
+    characterRepository = module.get(getRepositoryToken(CharacterEntity));
+
+    characterRepository.findOne.mockResolvedValue({
+      id: 'character-1',
+      account: { id: 'account-1', userId: 'user-1' },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('getSpecializations', () => {
+    it('should query all specializations ordered by sortOrder then name', async () => {
+      specializationRepository.find.mockResolvedValue([{ id: 'spec-1' }]);
+
+      const result = await service.getSpecializations();
+
+      expect(result).toEqual([{ id: 'spec-1' }]);
+      expect(specializationRepository.find).toHaveBeenCalledWith({
+        order: { sortOrder: 'ASC', name: 'ASC' },
+      });
+    });
+  });
+
+  describe('getProgress', () => {
+    const specializations = [
+      { id: 'spec-a', name: 'Pilot', type: 'primary', maxPoints: 30 },
+      { id: 'spec-b', name: 'Strategist', type: 'secondary', maxPoints: 15 },
+    ];
+
+    it('should throw NotFoundException when character does not exist', async () => {
+      characterRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.getProgress('missing-character', 'user-1'),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should throw ForbiddenException when character belongs to another user', async () => {
+      characterRepository.findOne.mockResolvedValue({
+        id: 'character-1',
+        account: { id: 'account-1', userId: 'other-user' },
+      });
+
+      await expect(
+        service.getProgress('character-1', 'user-1'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should return existing and synthetic entries for all specializations', async () => {
+      specializationRepository.find.mockResolvedValue(specializations);
+      progressRepository.find.mockResolvedValue([
+        {
+          id: 'progress-1',
+          characterId: 'character-1',
+          specializationId: 'spec-b',
+          specialization: specializations[1],
+          pointsSpent: 9,
+          slot: 'secondary',
+        },
+      ]);
+
+      const result = await service.getProgress('character-1', 'user-1');
+
+      expect(result).toHaveLength(2);
+      expect(
+        result.find((item: any) => item.specializationId === 'spec-a'),
+      ).toMatchObject({
+        id: '',
+        characterId: 'character-1',
+        specializationId: 'spec-a',
+        pointsSpent: 0,
+        slot: null,
+      });
+      expect(
+        result.find((item: any) => item.specializationId === 'spec-b'),
+      ).toMatchObject({
+        id: 'progress-1',
+        pointsSpent: 9,
+        slot: 'secondary',
+      });
+      expect(progressRepository.find).toHaveBeenCalledWith({
+        where: { characterId: 'character-1' },
+        relations: { specialization: true },
+      });
+    });
+  });
+
+  describe('updateProgress', () => {
+    const dto: UpdateCharacterSpecializationProgressDto = { pointsSpent: 20 };
+
+    it('should throw NotFoundException when the specialization does not exist', async () => {
+      specializationRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updateProgress('character-1', 'user-1', 'missing-spec', dto),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should reject points above the specialization maximum', async () => {
+      specializationRepository.findOne.mockResolvedValue({
+        id: 'spec-b',
+        name: 'Strategist',
+        type: 'secondary',
+        maxPoints: 15,
+      });
+
+      await expect(
+        service.updateProgress('character-1', 'user-1', 'spec-b', dto),
+      ).rejects.toThrow(BadRequestException);
+      expect(progressRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should create and save a new progress record when one does not exist', async () => {
+      const specialization = {
+        id: 'spec-a',
+        name: 'Pilot',
+        type: 'primary',
+        maxPoints: 30,
+      };
+      const created = {
+        characterId: 'character-1',
+        specializationId: 'spec-a',
+        pointsSpent: 0,
+        slot: null,
+      };
+
+      specializationRepository.findOne.mockResolvedValue(specialization);
+      progressRepository.findOne.mockResolvedValue(null);
+      progressRepository.create.mockReturnValue(created);
+      progressRepository.save.mockResolvedValue(created);
+
+      const result = await service.updateProgress(
+        'character-1',
+        'user-1',
+        'spec-a',
+        dto,
+      );
+
+      expect(progressRepository.create).toHaveBeenCalledWith({
+        characterId: 'character-1',
+        specializationId: 'spec-a',
+        pointsSpent: 0,
+        slot: null,
+      });
+      expect(progressRepository.save).toHaveBeenCalledWith(created);
+      expect(result.pointsSpent).toBe(20);
+      expect(result.specialization).toEqual(specialization);
+    });
+
+    it('should update and save an existing progress record', async () => {
+      const specialization = {
+        id: 'spec-a',
+        name: 'Pilot',
+        type: 'primary',
+        maxPoints: 30,
+      };
+      const existing = {
+        id: 'progress-existing',
+        characterId: 'character-1',
+        specializationId: 'spec-a',
+        pointsSpent: 3,
+        slot: null,
+        specialization,
+      };
+
+      specializationRepository.findOne.mockResolvedValue(specialization);
+      progressRepository.findOne.mockResolvedValue(existing);
+      progressRepository.save.mockResolvedValue(existing);
+
+      const result = await service.updateProgress(
+        'character-1',
+        'user-1',
+        'spec-a',
+        dto,
+      );
+
+      expect(progressRepository.create).not.toHaveBeenCalled();
+      expect(existing.pointsSpent).toBe(20);
+      expect(progressRepository.save).toHaveBeenCalledWith(existing);
+      expect(result.specialization).toEqual(specialization);
+    });
+  });
+
+  describe('updateSlot', () => {
+    const primarySpec = {
+      id: 'spec-a',
+      name: 'Pilot',
+      type: 'primary',
+      maxPoints: 30,
+    };
+    const secondarySpec = {
+      id: 'spec-b',
+      name: 'Strategist',
+      type: 'secondary',
+      maxPoints: 15,
+    };
+
+    it('should throw NotFoundException when the specialization does not exist', async () => {
+      specializationRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        service.updateSlot('character-1', 'user-1', 'missing-spec', {
+          slot: 'primary',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('should reject slotting a secondary-only specialization as primary', async () => {
+      specializationRepository.findOne.mockResolvedValue(secondarySpec);
+
+      await expect(
+        service.updateSlot('character-1', 'user-1', 'spec-b', {
+          slot: 'primary',
+        }),
+      ).rejects.toThrow(BadRequestException);
+      expect(progressRepository.save).not.toHaveBeenCalled();
+    });
+
+    it('should release the slot from any other specialization before claiming it', async () => {
+      const existing = {
+        id: 'progress-1',
+        characterId: 'character-1',
+        specializationId: 'spec-a',
+        pointsSpent: 12,
+        slot: null,
+        specialization: primarySpec,
+      };
+
+      specializationRepository.findOne.mockResolvedValue(primarySpec);
+      progressRepository.findOne.mockResolvedValue(existing);
+      progressRepository.save.mockResolvedValue(existing);
+
+      const result = await service.updateSlot(
+        'character-1',
+        'user-1',
+        'spec-a',
+        { slot: 'primary' },
+      );
+
+      expect(progressRepository.update).toHaveBeenCalledWith(
+        {
+          characterId: 'character-1',
+          slot: 'primary',
+          specializationId: Not('spec-a'),
+        },
+        { slot: null },
+      );
+      expect(result.slot).toBe('primary');
+      expect(progressRepository.save).toHaveBeenCalledWith(existing);
+    });
+
+    it('should clear the slot without touching other rows', async () => {
+      const existing = {
+        id: 'progress-1',
+        characterId: 'character-1',
+        specializationId: 'spec-b',
+        pointsSpent: 15,
+        slot: 'secondary',
+        specialization: secondarySpec,
+      };
+
+      specializationRepository.findOne.mockResolvedValue(secondarySpec);
+      progressRepository.findOne.mockResolvedValue(existing);
+      progressRepository.save.mockResolvedValue(existing);
+
+      const result = await service.updateSlot(
+        'character-1',
+        'user-1',
+        'spec-b',
+        { slot: null },
+      );
+
+      expect(progressRepository.update).not.toHaveBeenCalled();
+      expect(result.slot).toBeNull();
+    });
+  });
+
+  describe('getSummary', () => {
+    it('should return zero percentages when no specializations exist', async () => {
+      specializationRepository.find.mockResolvedValue([]);
+      progressRepository.find.mockResolvedValue([]);
+
+      const result = await service.getSummary('character-1', 'user-1');
+
+      expect(result).toEqual({
+        totalPoints: 0,
+        maxPossiblePoints: 0,
+        overallCompletionPercentage: 0,
+        completedSpecializations: 0,
+        totalSpecializations: 0,
+        primarySpecializationName: null,
+        secondarySpecializationName: null,
+      });
+    });
+
+    it('should total points against each specialization maximum and report the active slots', async () => {
+      specializationRepository.find.mockResolvedValue([
+        { id: 'spec-1', name: 'Pilot', type: 'primary', maxPoints: 30 },
+        {
+          id: 'spec-2',
+          name: 'Command Officer',
+          type: 'primary',
+          maxPoints: 30,
+        },
+        { id: 'spec-3', name: 'Strategist', type: 'secondary', maxPoints: 15 },
+      ]);
+      progressRepository.find.mockResolvedValue([
+        { specializationId: 'spec-1', pointsSpent: 30, slot: 'primary' },
+        { specializationId: 'spec-3', pointsSpent: 7, slot: 'secondary' },
+      ]);
+
+      const result = await service.getSummary('character-1', 'user-1');
+
+      expect(result).toEqual({
+        totalPoints: 37,
+        maxPossiblePoints: 75,
+        overallCompletionPercentage: 49,
+        completedSpecializations: 1,
+        totalSpecializations: 3,
+        primarySpecializationName: 'Pilot',
+        secondarySpecializationName: 'Strategist',
+      });
+      expect(progressRepository.find).toHaveBeenCalledWith({
+        where: { characterId: 'character-1' },
+      });
+    });
+  });
+});

--- a/src/sto/character-specialization/character-specialization.service.ts
+++ b/src/sto/character-specialization/character-specialization.service.ts
@@ -133,8 +133,9 @@ export class CharacterSpecializationService {
 
   /**
    * Activates a specialization in the character's Primary or Secondary slot, or
-   * deactivates it. A slot holds a single specialization, so whichever
-   * specialization previously held the requested slot is released first.
+   * deactivates it. The release of any existing holder and the claim of the
+   * requested slot are performed within a single transaction so slot
+   * assignment remains atomic under the partial unique slot index.
    *
    * @param characterId - The character id.
    * @param userId - The user id.
@@ -160,23 +161,30 @@ export class CharacterSpecializationService {
       );
     }
 
-    if (slot) {
-      await this._progressRepository.update(
-        { characterId, slot, specializationId: Not(specializationId) },
-        { slot: null },
+    return this._progressRepository.manager.transaction(async manager => {
+      const progressRepository = manager.getRepository(
+        CharacterSpecializationProgressEntity,
       );
-    }
 
-    const progress = await this._findOrCreateProgress(
-      characterId,
-      specializationId,
-    );
-    progress.slot = slot;
+      if (slot) {
+        await progressRepository.update(
+          { characterId, slot, specializationId: Not(specializationId) },
+          { slot: null },
+        );
+      }
 
-    await this._progressRepository.save(progress);
+      const progress = await this._findOrCreateProgress(
+        characterId,
+        specializationId,
+        progressRepository,
+      );
+      progress.slot = slot;
 
-    progress.specialization = specialization;
-    return progress;
+      await progressRepository.save(progress);
+
+      progress.specialization = specialization;
+      return progress;
+    });
   }
 
   /**
@@ -267,20 +275,24 @@ export class CharacterSpecializationService {
    *
    * @param characterId - The character id.
    * @param specializationId - The specialization id.
+   * @param progressRepository - The repository to use for the lookup and save
+   *   operations. Defaults to the service's injected progress repository.
    * @returns A promise that resolves when the operation completes.
    */
   private async _findOrCreateProgress(
     characterId: string,
     specializationId: string,
+    progressRepository: Repository<CharacterSpecializationProgressEntity> = this
+      ._progressRepository,
   ): Promise<CharacterSpecializationProgressEntity> {
-    const existing = await this._progressRepository.findOne({
+    const existing = await progressRepository.findOne({
       where: { characterId, specializationId },
       relations: { specialization: true },
     });
 
     return (
       existing ??
-      this._progressRepository.create({
+      progressRepository.create({
         characterId,
         specializationId,
         pointsSpent: 0,

--- a/src/sto/character-specialization/character-specialization.service.ts
+++ b/src/sto/character-specialization/character-specialization.service.ts
@@ -1,0 +1,291 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { CharacterOwnershipService } from 'src/sto/character/character-ownership.service';
+import { Not, Repository } from 'typeorm';
+import { UpdateCharacterSpecializationProgressDto } from './dto/update-character-specialization-progress.dto';
+import { UpdateCharacterSpecializationSlotDto } from './dto/update-character-specialization-slot.dto';
+import { CharacterSpecializationProgressEntity } from './entities/character-specialization-progress.entity';
+import { CharacterSpecializationEntity } from './entities/character-specialization.entity';
+
+export interface CharacterSpecializationSummary {
+  totalPoints: number;
+  maxPossiblePoints: number;
+  overallCompletionPercentage: number;
+  completedSpecializations: number;
+  totalSpecializations: number;
+  primarySpecializationName: string | null;
+  secondarySpecializationName: string | null;
+}
+
+@Injectable()
+export class CharacterSpecializationService {
+  /**
+   * Creates an instance of CharacterSpecializationService.
+   *
+   * @param _specializationRepository - The specialization catalog repository.
+   * @param _progressRepository - The progress repository.
+   * @param _characterOwnership - The shared character ownership guard.
+   */
+  constructor(
+    @InjectRepository(CharacterSpecializationEntity)
+    private readonly _specializationRepository: Repository<CharacterSpecializationEntity>,
+    @InjectRepository(CharacterSpecializationProgressEntity)
+    private readonly _progressRepository: Repository<CharacterSpecializationProgressEntity>,
+    private readonly _characterOwnership: CharacterOwnershipService,
+  ) {}
+
+  /**
+   * Gets the captain specialization catalog.
+   *
+   * @returns A promise that resolves when the operation completes.
+   */
+  async getSpecializations(): Promise<CharacterSpecializationEntity[]> {
+    return this._specializationRepository.find({
+      order: { sortOrder: 'ASC', name: 'ASC' },
+    });
+  }
+
+  /**
+   * Gets specialization progress for a character.
+   *
+   * @param characterId - The character id.
+   * @param userId - The user id.
+   * @returns A promise that resolves when the operation completes.
+   */
+  async getProgress(
+    characterId: string,
+    userId: string,
+  ): Promise<CharacterSpecializationProgressEntity[]> {
+    await this._characterOwnership.requireOwnedCharacter(characterId, userId);
+
+    const allSpecializations = await this.getSpecializations();
+
+    const existingProgress = await this._progressRepository.find({
+      where: { characterId },
+      relations: { specialization: true },
+    });
+
+    const progressMap = new Map(
+      existingProgress.map(p => [p.specializationId, p]),
+    );
+
+    // Return one record per specialization, synthesising zero-progress entries
+    // for the ones the character has never spent a point in.
+    return allSpecializations.map(specialization => {
+      const existing = progressMap.get(specialization.id);
+      if (existing) {
+        return existing;
+      }
+
+      const synthetic = new CharacterSpecializationProgressEntity();
+      synthetic.id = '';
+      synthetic.characterId = characterId;
+      synthetic.specializationId = specialization.id;
+      synthetic.specialization = specialization;
+      synthetic.pointsSpent = 0;
+      synthetic.slot = null;
+      return synthetic;
+    });
+  }
+
+  /**
+   * Updates the points spent in one specialization for a character.
+   *
+   * @param characterId - The character id.
+   * @param userId - The user id.
+   * @param specializationId - The specialization id.
+   * @param dto - The dto.
+   * @returns A promise that resolves when the operation completes.
+   */
+  async updateProgress(
+    characterId: string,
+    userId: string,
+    specializationId: string,
+    dto: UpdateCharacterSpecializationProgressDto,
+  ): Promise<CharacterSpecializationProgressEntity> {
+    await this._characterOwnership.requireOwnedCharacter(characterId, userId);
+
+    const specialization = await this._requireSpecialization(specializationId);
+
+    // Secondary-only specializations cap at fewer points than the DTO's upper
+    // bound allows, so the per-specialization maximum is checked here.
+    if (dto.pointsSpent > specialization.maxPoints) {
+      throw new BadRequestException(
+        `"${specialization.name}" accepts at most ${specialization.maxPoints} specialization points`,
+      );
+    }
+
+    const progress = await this._findOrCreateProgress(
+      characterId,
+      specializationId,
+    );
+    progress.pointsSpent = dto.pointsSpent;
+
+    await this._progressRepository.save(progress);
+
+    progress.specialization = specialization;
+    return progress;
+  }
+
+  /**
+   * Activates a specialization in the character's Primary or Secondary slot, or
+   * deactivates it. A slot holds a single specialization, so whichever
+   * specialization previously held the requested slot is released first.
+   *
+   * @param characterId - The character id.
+   * @param userId - The user id.
+   * @param specializationId - The specialization id.
+   * @param dto - The dto.
+   * @returns A promise that resolves when the operation completes.
+   */
+  async updateSlot(
+    characterId: string,
+    userId: string,
+    specializationId: string,
+    dto: UpdateCharacterSpecializationSlotDto,
+  ): Promise<CharacterSpecializationProgressEntity> {
+    await this._characterOwnership.requireOwnedCharacter(characterId, userId);
+
+    const specialization = await this._requireSpecialization(specializationId);
+
+    const slot = dto.slot ?? null;
+
+    if (slot === 'primary' && specialization.type !== 'primary') {
+      throw new BadRequestException(
+        `"${specialization.name}" is a secondary-only specialization and cannot be slotted as primary`,
+      );
+    }
+
+    if (slot) {
+      await this._progressRepository.update(
+        { characterId, slot, specializationId: Not(specializationId) },
+        { slot: null },
+      );
+    }
+
+    const progress = await this._findOrCreateProgress(
+      characterId,
+      specializationId,
+    );
+    progress.slot = slot;
+
+    await this._progressRepository.save(progress);
+
+    progress.specialization = specialization;
+    return progress;
+  }
+
+  /**
+   * Gets the specialization summary for a character.
+   *
+   * @param characterId - The character id.
+   * @param userId - The user id.
+   * @returns A promise that resolves when the operation completes.
+   */
+  async getSummary(
+    characterId: string,
+    userId: string,
+  ): Promise<CharacterSpecializationSummary> {
+    await this._characterOwnership.requireOwnedCharacter(characterId, userId);
+
+    const allSpecializations = await this._specializationRepository.find();
+    const existingProgress = await this._progressRepository.find({
+      where: { characterId },
+    });
+
+    const progressMap = new Map(
+      existingProgress.map(p => [p.specializationId, p]),
+    );
+
+    let totalPoints = 0;
+    let maxPossiblePoints = 0;
+    let completedSpecializations = 0;
+    let primarySpecializationName: string | null = null;
+    let secondarySpecializationName: string | null = null;
+
+    for (const specialization of allSpecializations) {
+      const progress = progressMap.get(specialization.id);
+      const points = progress?.pointsSpent ?? 0;
+
+      totalPoints += points;
+      maxPossiblePoints += specialization.maxPoints;
+
+      if (points >= specialization.maxPoints) {
+        completedSpecializations++;
+      }
+
+      if (progress?.slot === 'primary') {
+        primarySpecializationName = specialization.name;
+      } else if (progress?.slot === 'secondary') {
+        secondarySpecializationName = specialization.name;
+      }
+    }
+
+    return {
+      totalPoints,
+      maxPossiblePoints,
+      overallCompletionPercentage:
+        maxPossiblePoints > 0
+          ? Math.round((totalPoints / maxPossiblePoints) * 100)
+          : 0,
+      completedSpecializations,
+      totalSpecializations: allSpecializations.length,
+      primarySpecializationName,
+      secondarySpecializationName,
+    };
+  }
+
+  /**
+   * Loads a catalog specialization, throwing when it does not exist.
+   *
+   * @param specializationId - The specialization id.
+   * @returns A promise that resolves when the operation completes.
+   */
+  private async _requireSpecialization(
+    specializationId: string,
+  ): Promise<CharacterSpecializationEntity> {
+    const specialization = await this._specializationRepository.findOne({
+      where: { id: specializationId },
+    });
+
+    if (!specialization) {
+      throw new NotFoundException(
+        `Specialization with ID "${specializationId}" not found`,
+      );
+    }
+
+    return specialization;
+  }
+
+  /**
+   * Loads the character's progress row for a specialization, creating an unsaved
+   * zero-progress row when the character has never tracked it before.
+   *
+   * @param characterId - The character id.
+   * @param specializationId - The specialization id.
+   * @returns A promise that resolves when the operation completes.
+   */
+  private async _findOrCreateProgress(
+    characterId: string,
+    specializationId: string,
+  ): Promise<CharacterSpecializationProgressEntity> {
+    const existing = await this._progressRepository.findOne({
+      where: { characterId, specializationId },
+      relations: { specialization: true },
+    });
+
+    return (
+      existing ??
+      this._progressRepository.create({
+        characterId,
+        specializationId,
+        pointsSpent: 0,
+        slot: null,
+      })
+    );
+  }
+}

--- a/src/sto/character-specialization/dto/update-character-specialization-progress.dto.ts
+++ b/src/sto/character-specialization/dto/update-character-specialization-progress.dto.ts
@@ -1,0 +1,9 @@
+import { IsInt, Max, Min } from 'class-validator';
+import { SPECIALIZATION_PRIMARY_MAX_POINTS } from '../entities/character-specialization.entity';
+
+export class UpdateCharacterSpecializationProgressDto {
+  @IsInt()
+  @Min(0)
+  @Max(SPECIALIZATION_PRIMARY_MAX_POINTS)
+  pointsSpent: number;
+}

--- a/src/sto/character-specialization/dto/update-character-specialization-slot.dto.ts
+++ b/src/sto/character-specialization/dto/update-character-specialization-slot.dto.ts
@@ -1,0 +1,12 @@
+import { IsIn, IsOptional } from 'class-validator';
+import { SpecializationSlot } from '../entities/character-specialization-progress.entity';
+
+export class UpdateCharacterSpecializationSlotDto {
+  /**
+   * The captain slot to activate this specialization in, or null to deactivate
+   * it. Assigning a slot moves it off whichever specialization held it before.
+   */
+  @IsOptional()
+  @IsIn(['primary', 'secondary'])
+  slot: SpecializationSlot | null;
+}

--- a/src/sto/character-specialization/dto/update-character-specialization-slot.dto.ts
+++ b/src/sto/character-specialization/dto/update-character-specialization-slot.dto.ts
@@ -1,4 +1,4 @@
-import { IsIn, IsOptional } from 'class-validator';
+import { IsIn } from 'class-validator';
 import { SpecializationSlot } from '../entities/character-specialization-progress.entity';
 
 export class UpdateCharacterSpecializationSlotDto {
@@ -6,7 +6,6 @@ export class UpdateCharacterSpecializationSlotDto {
    * The captain slot to activate this specialization in, or null to deactivate
    * it. Assigning a slot moves it off whichever specialization held it before.
    */
-  @IsOptional()
-  @IsIn(['primary', 'secondary'])
+  @IsIn(['primary', 'secondary', null])
   slot: SpecializationSlot | null;
 }

--- a/src/sto/character-specialization/entities/character-specialization-progress.entity.ts
+++ b/src/sto/character-specialization/entities/character-specialization-progress.entity.ts
@@ -1,0 +1,115 @@
+import { Expose } from 'class-transformer';
+import { IsInt, IsOptional, IsUUID, Max, Min } from 'class-validator';
+import { CharacterEntity } from 'src/sto/character/entities/character.entity';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import {
+  CharacterSpecializationEntity,
+  SPECIALIZATION_PRIMARY_MAX_POINTS,
+  SPECIALIZATION_QUALIFICATION_POINTS,
+} from './character-specialization.entity';
+
+/**
+ * The captain slot a specialization is currently active in. A character may
+ * have at most one Primary and one Secondary specialization active at a time;
+ * everything else is purchased but inactive.
+ */
+export type SpecializationSlot = 'primary' | 'secondary';
+
+@Entity({ name: 'character_specialization_progress' })
+@Index(
+  'UX_character_specialization_progress_character_specialization',
+  ['characterId', 'specializationId'],
+  {
+    unique: true,
+  },
+)
+export class CharacterSpecializationProgressEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @IsUUID()
+  @Column({ type: 'uuid', nullable: false })
+  characterId: string;
+
+  @IsUUID()
+  @Column({ type: 'uuid', nullable: false })
+  specializationId: string;
+
+  @IsInt()
+  @Min(0)
+  @Max(SPECIALIZATION_PRIMARY_MAX_POINTS)
+  @Column({ type: 'int', default: 0, nullable: false })
+  pointsSpent: number;
+
+  @IsOptional()
+  @Column({ type: 'varchar', length: 16, nullable: true })
+  slot: SpecializationSlot | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  @ManyToOne('CharacterEntity', { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'characterId' })
+  character: CharacterEntity;
+
+  @ManyToOne('CharacterSpecializationEntity', {
+    eager: true,
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'specializationId' })
+  specialization: CharacterSpecializationEntity;
+
+  @Expose()
+  /**
+   * Gets the progress status.
+   *
+   * @returns The result of the operation.
+   */
+  get status(): 'not_started' | 'in_progress' | 'complete' {
+    if (this.pointsSpent === 0) return 'not_started';
+    if (this.pointsSpent >= this.maxPoints) return 'complete';
+    return 'in_progress';
+  }
+
+  @Expose()
+  /**
+   * Gets the completion percentage.
+   *
+   * @returns The result of the operation.
+   */
+  get completionPercentage(): number {
+    if (this.maxPoints <= 0) return 0;
+    return Math.round((this.pointsSpent / this.maxPoints) * 100);
+  }
+
+  @Expose()
+  /**
+   * Gets whether the Specialization Qualification for training bridge officers
+   * has been unlocked. Secondary-only specializations have no qualification.
+   *
+   * @returns The result of the operation.
+   */
+  get qualificationUnlocked(): boolean {
+    return (
+      this.specialization?.type === 'primary' &&
+      this.pointsSpent >= SPECIALIZATION_QUALIFICATION_POINTS
+    );
+  }
+
+  /** The point total that fully completes this specialization. */
+  private get maxPoints(): number {
+    return this.specialization?.maxPoints ?? SPECIALIZATION_PRIMARY_MAX_POINTS;
+  }
+}

--- a/src/sto/character-specialization/entities/character-specialization.entity.ts
+++ b/src/sto/character-specialization/entities/character-specialization.entity.ts
@@ -1,0 +1,47 @@
+import { IsIn, IsInt, Max, Min } from 'class-validator';
+import { CatalogItemEntity } from 'src/sto/shared/entities/catalog-item.entity';
+import { Column, Entity, Index, OneToMany } from 'typeorm';
+import { CharacterSpecializationProgressEntity } from './character-specialization-progress.entity';
+
+/**
+ * Whether a specialization can be slotted as a captain's Primary (and therefore
+ * also as their Secondary), or is a Secondary-only specialization.
+ */
+export type SpecializationType = 'primary' | 'secondary';
+
+/** Points needed to fully purchase a Primary-capable specialization. */
+export const SPECIALIZATION_PRIMARY_MAX_POINTS = 30;
+
+/** Points needed to fully purchase a Secondary-only specialization. */
+export const SPECIALIZATION_SECONDARY_MAX_POINTS = 15;
+
+/**
+ * Points that must be spent in a Primary-capable specialization before its
+ * Specialization Qualification (bridge officer training manual) can be crafted.
+ */
+export const SPECIALIZATION_QUALIFICATION_POINTS = 10;
+
+@Entity({ name: 'character_specialization' })
+@Index('UX_character_specialization_name', ['name'], { unique: true })
+export class CharacterSpecializationEntity extends CatalogItemEntity {
+  @IsIn(['primary', 'secondary'])
+  @Column({ type: 'varchar', length: 16, nullable: false })
+  type: SpecializationType;
+
+  @IsInt()
+  @Min(1)
+  @Max(SPECIALIZATION_PRIMARY_MAX_POINTS)
+  @Column({
+    type: 'int',
+    default: SPECIALIZATION_PRIMARY_MAX_POINTS,
+    nullable: false,
+  })
+  maxPoints: number;
+
+  @OneToMany(
+    'CharacterSpecializationProgressEntity',
+    (progress: CharacterSpecializationProgressEntity) =>
+      progress.specialization,
+  )
+  characterProgress: CharacterSpecializationProgressEntity[];
+}


### PR DESCRIPTION
## Description

This change introduces the ability to track and manage character specializations from Star Trek Online (STO). It includes the necessary database schema, API endpoints, and business logic to allow users to record points spent in specializations, assign primary or secondary active slots, and view their overall progress. The initial set of official specializations is seeded into the database upon migration.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Breaking change (explain below)

## Checklist

- [x] My PR title follows the [Semantic PR](https://www.conventionalcommits.org/) format (e.g., `feat: add something`, `fix: resolve issue`).
- [x] I have added/updated tests to cover my changes.
- [x] I have updated the documentation where necessary.
- [x] I have considered the security implications of these changes.
- [ ] I have verified that no sensitive data (secrets, keys, PII) is included in my code, logs, or screenshots.

## Further Notes

Relates to SC-1033

Signed-off-by: Steve Roberts <steve@shadowcomputers.co.uk>